### PR TITLE
Add virtual destructor to ButtonAction + extra warning flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.10)
 project(logiops)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -Wall")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -Wall -Wextra")
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/src/logid/Actions.h
+++ b/src/logid/Actions.h
@@ -37,7 +37,7 @@ class Device;
 class ButtonAction
 {
 public:
-	virtual ~ButtonAction() = default;
+    virtual ~ButtonAction() = default;
 
     Action type;
     virtual ButtonAction* copy(Device* dev) = 0;

--- a/src/logid/Actions.h
+++ b/src/logid/Actions.h
@@ -37,6 +37,8 @@ class Device;
 class ButtonAction
 {
 public:
+	virtual ~ButtonAction() = default;
+
     Action type;
     virtual ButtonAction* copy(Device* dev) = 0;
     virtual void press() = 0;


### PR DESCRIPTION
Added a virtual destructor to _ButtonAction_. Since it's an abstract class, a virtual destructor is required so that instances of derived classes can be correctly destroyed when referenced by a pointer/reference of type _ButtonAction_.

Also added the flag -Wextra to CMakeLists.txt so that more potential errors can be seen sooner. There seems to be no new warning raised by adding this flag, currently.