### PR TITLE
Fix error with  asleep device + critical section protection + general refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/build
+*.swp
+*~
+/compile_commands.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.10)
 project(logiops)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -Wall -Wextra")
 

--- a/src/logid/Device.cpp
+++ b/src/logid/Device.cpp
@@ -248,19 +248,7 @@ void ReceiverHandler::handleEvent(const HIDPP::Report &event)
     {
         case HIDPP10::IReceiver::DeviceUnpaired:
         {
-            // Find device, stop it, and delete it
-            auto it = finder->devices.begin();
-            while (it != finder->devices.end())
-            {
-                if(it->first->path == dev->path && it->first->index == event.deviceIndex())
-                {
-                    log_printf(INFO, "%s (Device %d on %s) unpaired.", it->first->name.c_str(), event.deviceIndex(), dev->path.c_str());
-                    it->first->stop();
-                    it->second.join();
-                    finder->devices.erase(it);
-                }
-                else it++;
-            }
+            finder->stopAndDeleteDevice(dev->path, event.deviceIndex());
             break;
         }
         case HIDPP10::IReceiver::DevicePaired:

--- a/src/logid/DeviceFinder.cpp
+++ b/src/logid/DeviceFinder.cpp
@@ -9,10 +9,14 @@
 #include <thread>
 #include <fstream>
 #include <sstream>
+#include <chrono>
 
 #include "DeviceFinder.h"
 #include "util.h"
 #include "Device.h"
+
+#define MAX_CONNECTION_TRIES 10
+#define TIME_BETWEEN_CONNECTION_TRIES 1s
 
 void stopAndDeletePairedDevice (PairedDevice &pairedDevice)
 {
@@ -86,12 +90,12 @@ void DeviceFinder::stopAndDeleteDevice (const std::string &path, HIDPP::DeviceIn
 
 void DeviceFinder::addDevice(const char *path)
 {
+    using namespace std::chrono_literals;
+
     std::string string_path(path);
     // Asynchronously scan device
     std::thread{[=]()
     {
-        const int max_tries = 10;
-        const int try_delay = 250000;
 
         //Check if device is an HID++ device and handle it accordingly
         try
@@ -107,8 +111,11 @@ void DeviceFinder::addDevice(const char *path)
 
                 if(!has_receiver_index && index == HIDPP::WirelessDevice1)
                     break;
-                for(int i = 0; i < max_tries; i++)
-                {
+
+                bool device_not_connected = true;
+                bool device_unknown = false;
+                int remaining_tries = MAX_CONNECTION_TRIES;
+                do {
                     try
                     {
                         HIDPP::Device d(&dispatcher, index);
@@ -121,42 +128,45 @@ void DeviceFinder::addDevice(const char *path)
                         {
                             this->insertNewDevice(string_path, index);
                         }
-                        break;
+                        device_not_connected = false;
                     }
                     catch(HIDPP10::Error &e)
                     {
                         if(e.errorCode() != HIDPP10::Error::UnknownDevice)
                         {
-                            if(i == max_tries - 1)
-                                log_printf(ERROR, "Error while querying %s, wireless device %d: %s", string_path.c_str(), index, e.what());
-                            else usleep(try_delay);
+                            if(remaining_tries == 1)
+                            {
+                                log_printf(WARN, "While querying %s, wireless device %d: %s", string_path.c_str(), index, e.what());
+                                remaining_tries += MAX_CONNECTION_TRIES;    // asleep wireless devices may raise this error, so warn but do not stop querying device
+                            }
                         }
-                        else break;
+                        else device_unknown = true;
                     }
                     catch(HIDPP20::Error &e)
                     {
                         if(e.errorCode() != HIDPP20::Error::UnknownDevice)
                         {
-                            if(i == max_tries - 1)
+                            if(remaining_tries == 1)
                                 log_printf(ERROR, "Error while querying %s, device %d: %s", string_path.c_str(), index, e.what());
-                            else usleep(try_delay);
                         }
-                        else break;
+                        else device_unknown = true;
                     }
                     catch(HIDPP::Dispatcher::TimeoutError &e)
                     {
-                        if(i == max_tries - 1)
+                        if(remaining_tries == 1)
                             log_printf(ERROR, "Device %s (index %d) timed out.", string_path.c_str(), index);
-                        else usleep(try_delay);
                     }
                     catch(std::runtime_error &e)
                     {
-                        if(i == max_tries - 1)
+                        if(remaining_tries == 1)
                             log_printf(ERROR, "Runtime error on device %d on %s: %s", index, string_path.c_str(), e.what());
-                        else usleep(try_delay);
                     }
-                }
-            }
+
+                    remaining_tries--;
+                    std::this_thread::sleep_for(TIME_BETWEEN_CONNECTION_TRIES);
+
+                } while (device_not_connected && !device_unknown && remaining_tries > 0);
+            } 
         }
         catch(HIDPP::Dispatcher::NoHIDPPReportException &e) { }
         catch(std::system_error &e) { log_printf(WARN, "Failed to open %s: %s", string_path.c_str(), e.what()); }

--- a/src/logid/DeviceFinder.cpp
+++ b/src/logid/DeviceFinder.cpp
@@ -18,7 +18,7 @@
 #define MAX_CONNECTION_TRIES 10
 #define TIME_BETWEEN_CONNECTION_TRIES 1s
 
-void stopAndDeletePairedDevice (ConnectedDevice &connected_device)
+void stopAndDeleteConnectedDevice (ConnectedDevice &connected_device)
 {
     log_printf(INFO, "%s (Device %d on %s) disconnected", connected_device.device->name.c_str(), connected_device.device->index, connected_device.device->path.c_str()); 
     connected_device.device->stop();
@@ -31,7 +31,7 @@ DeviceFinder::~DeviceFinder()
     this->devices_mutex.lock();
         for (auto it = this->devices.begin(); it != this->devices.end(); it++) {
             for (auto jt = it->second.begin(); jt != it->second.end(); jt++) {
-                stopAndDeletePairedDevice(jt->second);
+                stopAndDeleteConnectedDevice(jt->second);
             }
         }
     this->devices_mutex.unlock();
@@ -60,7 +60,7 @@ void DeviceFinder::stopAndDeleteAllDevicesIn (const std::string &path)
         if (path_bucket != this->devices.end())
         {
             for (auto& index_bucket : path_bucket->second) {
-                stopAndDeletePairedDevice(index_bucket.second);
+                stopAndDeleteConnectedDevice(index_bucket.second);
             }
             this->devices.erase(path_bucket);
         }
@@ -78,7 +78,7 @@ void DeviceFinder::stopAndDeleteDevice (const std::string &path, HIDPP::DeviceIn
             auto index_bucket = path_bucket->second.find(index);
             if (index_bucket != path_bucket->second.end())
             {
-                stopAndDeletePairedDevice(index_bucket->second);
+                stopAndDeleteConnectedDevice(index_bucket->second);
                 path_bucket->second.erase(index_bucket);
             }
         }

--- a/src/logid/DeviceFinder.cpp
+++ b/src/logid/DeviceFinder.cpp
@@ -132,13 +132,18 @@ void DeviceFinder::addDevice(const char *path)
                     }
                     catch(HIDPP10::Error &e)
                     {
-                        if(e.errorCode() != HIDPP10::Error::UnknownDevice)
+                        if (e.errorCode() == HIDPP10::Error::ResourceError)
                         {
                             if(remaining_tries == 1)
                             {
-                                log_printf(WARN, "While querying %s, wireless device %d: %s", string_path.c_str(), index, e.what());
-                                remaining_tries += MAX_CONNECTION_TRIES;    // asleep wireless devices may raise this error, so warn but do not stop querying device
-                            }
+                                log_printf(WARN, "While querying %s (possibly asleep), wireless device %d: %s", string_path.c_str(), index, e.what());
+                                remaining_tries += MAX_CONNECTION_TRIES;  // asleep devices may raise a resource error, so do not count this try
+                            } 
+                        }
+                        else if(e.errorCode() != HIDPP10::Error::UnknownDevice)
+                        {
+                            if(remaining_tries == 1)
+                                log_printf(ERROR, "While querying %s, wireless device %d: %s", string_path.c_str(), index, e.what());
                         }
                         else device_unknown = true;
                     }

--- a/src/logid/DeviceFinder.h
+++ b/src/logid/DeviceFinder.h
@@ -6,7 +6,6 @@
 #include <hidpp10/IReceiver.h>
 #include <hidpp20/IReprogControls.h>
 #include <map>
-#include <list>
 #include <thread>
 #include <mutex>
 

--- a/src/logid/DeviceFinder.h
+++ b/src/logid/DeviceFinder.h
@@ -5,7 +5,7 @@
 #include <hidpp10/Device.h>
 #include <hidpp10/IReceiver.h>
 #include <hidpp20/IReprogControls.h>
-#include <unordered_map>
+#include <map>
 #include <list>
 #include <thread>
 #include <mutex>

--- a/src/logid/DeviceFinder.h
+++ b/src/logid/DeviceFinder.h
@@ -14,7 +14,7 @@
 
 class Device;
 
-struct PairedDevice {
+struct ConnectedDevice {
 	Device *device;
 	std::thread associatedThread;
 };
@@ -31,8 +31,8 @@ protected:
     void addDevice(const char* path);
     void removeDevice(const char* path);
 private:
-	std::mutex devicesMutex;
-    std::map<std::string, std::map<HIDPP::DeviceIndex, PairedDevice>> devices;
+	std::mutex devices_mutex;
+    std::map<std::string, std::map<HIDPP::DeviceIndex, ConnectedDevice>> devices;
 };
 
 extern DeviceFinder* finder;

--- a/src/logid/DeviceFinder.h
+++ b/src/logid/DeviceFinder.h
@@ -5,22 +5,34 @@
 #include <hidpp10/Device.h>
 #include <hidpp10/IReceiver.h>
 #include <hidpp20/IReprogControls.h>
-#include <map>
+#include <unordered_map>
+#include <list>
 #include <thread>
-#include "Device.h"
 #include <mutex>
 
+#include "Device.h"
+
 class Device;
+
+struct PairedDevice {
+	Device *device;
+	std::thread associatedThread;
+};
 
 class DeviceFinder : public HID::DeviceMonitor
 {
 public:
-    std::map<Device*, std::thread> devices;
+	~DeviceFinder();
+
+	void insertNewDevice (const std::string &path, HIDPP::DeviceIndex index);
+	void stopAndDeleteAllDevicesIn (const std::string &path);
+	void stopAndDeleteDevice (const std::string &path, HIDPP::DeviceIndex index);
 protected:
     void addDevice(const char* path);
     void removeDevice(const char* path);
 private:
 	std::mutex devicesMutex;
+    std::map<std::string, std::map<HIDPP::DeviceIndex, PairedDevice>> devices;
 };
 
 extern DeviceFinder* finder;

--- a/src/logid/DeviceFinder.h
+++ b/src/logid/DeviceFinder.h
@@ -1,5 +1,4 @@
-#ifndef DEVICEFINDER_H
-#define DEVICEFINDER_H
+#pragma once
 
 #include <hid/DeviceMonitor.h>
 #include <hidpp/SimpleDispatcher.h>
@@ -9,6 +8,7 @@
 #include <map>
 #include <thread>
 #include "Device.h"
+#include <mutex>
 
 class Device;
 
@@ -19,8 +19,9 @@ public:
 protected:
     void addDevice(const char* path);
     void removeDevice(const char* path);
+private:
+	std::mutex devicesMutex;
 };
 
 extern DeviceFinder* finder;
 
-#endif //DEVICEFINDER_H


### PR DESCRIPTION
- General refactoring of DeviceFinder;
- Encapsulated DeviceFinder so that it is the only one responsible for removing devices, instead of exposing the collection of devices and having external classes/methods manipulate it;
- Added mutex to protect the collection of devices so that it cannot be invalidated by multiple threads changing it;
- Changed interval between connection tries to 1s;
- Fixed error where asleep wireless devices would raise resource errors and cause logid to stop querying the device. Now logid will only warn of resource errors but will not stop querying the device because of them. This was tested on a MX Master 2S.

Note: changes to CMake and .gitignore are specific to my development environment and won't have any negative impact to the project or to other people's environment. Can be removed if deemed necessary
