### PR TITLE
Fix DeviceConfig default initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ To install, run `sudo make install` after building. You can set the daemon to st
 |  Device   | Compatible? |
 |:---------:|:-----------:|
 | MX Master |     Yes     |
+|MX Vertical|     Yes     |
 |   T400    |     Yes     |
 |   K400r   |  Untested   |
 |   K350    |  Untested   |

--- a/src/logid/Configuration.h
+++ b/src/logid/Configuration.h
@@ -20,7 +20,7 @@ namespace logid
         DeviceConfig(DeviceConfig* dc, Device* dev);
         DeviceConfig(const libconfig::Setting& root);
         const int* dpi = nullptr;
-        HIDPP20::ISmartShift::SmartshiftStatus* smartshift;
+        HIDPP20::ISmartShift::SmartshiftStatus* smartshift = nullptr;
         const uint8_t* hiresscroll = nullptr;
         std::map<uint16_t, ButtonAction*> actions;
         const bool baseConfig = true;


### PR DESCRIPTION
Initialize smartshift to nullptr.
Otherwise, the device configuration contains a SmartshiftStatus, even if none was declared in the configuration file.
This causes later an error if the device does not support SmartShift.

I have not tested this version with a device supporting SmartShift.
(I am using a MX Vertical)