### PR TITLE
#87 Add string headers to allow building on latest gcc

### DIFF
--- a/src/logid/Configuration.cpp
+++ b/src/logid/Configuration.cpp
@@ -5,6 +5,7 @@
 #include <libevdev/libevdev.h>
 #include <algorithm>
 #include <cstring>
+#include <string>
 #include <hidpp20/IHiresScroll.h>
 
 #include "Configuration.h"


### PR DESCRIPTION
Add the include for string headers allows logiops to build on gcc 10.  Fixes issue #87 