### PR TITLE
add M590 to list of tested devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This project requires a C++14 compiler, cmake, libevdev, libudev, and libconfig.
 
 **Debian/Ubuntu:** `sudo apt install cmake libevdev-dev libudev-dev libconfig++-dev`
 
-**Arch Linux:** `sudo pacman -S cmake libevdev libconfig libudev`
+**Arch Linux:** `sudo pacman -S cmake libevdev libconfig pkgconf`
 
 ## Building
 

--- a/TESTED.md
+++ b/TESTED.md
@@ -10,4 +10,5 @@ This is not by any means an exhaustive list. Many more devices are supported but
 | MX Vertical  |     Yes     |
 |   MX Ergo    |     Yes     |
 |     M720     |     Yes     |
+|     M590     |     Yes     |
 |     T400     |     Yes     |


### PR DESCRIPTION
Tested M590 on Arch linux as well Ubuntu 20.04. Everything in my tests worked.

Also noticed that libudev is not a valid package in arch linux. I am not sure what the actual package is but it seems I already had the required so file on my system. I also had to install pkgconf for cmake to work