### PR TITLE
Indicate DEFAULT_CONFIG_FILE location

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ This is currently only compatible with HID++ \>2.0 devices.
 
 You may also refer to logid.example.cfg for an example.
 
+Default location for the configuration file is /etc/logid.cfg.
+
 ## Dependencies
 
 This project requires a C++14 compiler, cmake, libevdev, libudev, and libconfig. For popular distributions, I've included commands below. 


### PR DESCRIPTION
While fairly self-evident, would be helpful to mention to users where their logid.cfg is meant to go. This just adds one sentence to achieve just that.