### PR TITLE
Multiple button profiles

### DIFF
--- a/logid.example.cfg
+++ b/logid.example.cfg
@@ -15,62 +15,82 @@ devices: (
     dpi: 1000;
 
     buttons: (
-        {
-            cid: 0xc3;
-            action =
+        (
             {
-                type: "Gestures";
-                gestures: (
-                    {
-                        direction: "Up";
-                        mode: "OnRelease";
-                        action =
+                cid: 0xc3;
+                action =
+                {
+                    type: "Gestures";
+                    gestures: (
                         {
-                            type: "Keypress";
-                            keys: ["KEY_UP"];
-                        };
-                    },
-                    {
-                        direction: "Down";
-                        mode: "OnRelease";
-                        action =
+                            direction: "Up";
+                            mode: "OnRelease";
+                            action =
+                            {
+                                type: "Keypress";
+                                keys: ["KEY_UP"];
+                            };
+                        },
                         {
-                            type: "Keypress";
-                            keys: ["KEY_DOWN"];
-                        };
-                    },
-                    {
-                        direction: "Left";
-                        mode: "OnRelease";
-                        action =
+                            direction: "Down";
+                            mode: "OnRelease";
+                            action =
+                            {
+                                type: "Keypress";
+                                keys: ["KEY_DOWN"];
+                            };
+                        },
                         {
-                            type: "CycleDPI";
-                            dpis: [400, 600, 800, 1000, 1200, 1400, 1600];
-                        };
-                    },
-                    {
-                        direction: "Right";
-                        mode: "OnRelease";
-                        action =
+                            direction: "Left";
+                            mode: "OnRelease";
+                            action =
+                            {
+                                type: "CycleDPI";
+                                dpis: [400, 600, 800, 1000, 1200, 1400, 1600];
+                            };
+                        },
                         {
-                            type = "ToggleSmartshift";
+                            direction: "Right";
+                            mode: "OnRelease";
+                            action =
+                            {
+                                type = "ToggleSmartshift";
+                            }
+                        },
+                        {
+                            direction: "None"
+                            mode: "NoPress"
                         }
-                    },
-                    {
-                        direction: "None"
-                        mode: "NoPress"
-                    }
-                );
-            };
-        },
-        {
-            cid: 0xc4;
-            action =
+                    );
+                };
+            },
             {
-                type: "Keypress";
-                keys: ["KEY_A"];
-            };
-        }
+                cid: 0xc4;
+                action =
+                {
+                    type: "switchprofile";
+                    switchtype: "next";
+                };
+            }
+        ),
+        (
+            {
+                cid: 0xc4;
+                action =
+                {
+                    type: "switchprofile";
+                    switchtype: "next";
+                };
+            },
+            {
+                cid: 0x52;
+                action =
+                {
+                    type: "Keypress";
+                    keys: ["KEY_A"];
+                }
+            }
+        )
     );
 }
 );

--- a/src/logid/CMakeLists.txt
+++ b/src/logid/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(logid
         actions/ChangeDPI.cpp
         actions/GestureAction.cpp
         actions/ChangeHostAction.cpp
+        actions/SwitchProfileAction.cpp
         actions/gesture/Gesture.cpp
         actions/gesture/ReleaseGesture.cpp
         actions/gesture/IntervalGesture.cpp

--- a/src/logid/actions/Action.cpp
+++ b/src/logid/actions/Action.cpp
@@ -27,6 +27,7 @@
 #include "CycleDPI.h"
 #include "ChangeDPI.h"
 #include "ChangeHostAction.h"
+#include "SwitchProfileAction.h"
 
 using namespace logid;
 using namespace logid::actions;
@@ -68,6 +69,8 @@ std::shared_ptr<Action> Action::makeAction(Device *device, libconfig::Setting
             return std::make_shared<NullAction>(device);
         else if(type == "changehost")
             return std::make_shared<ChangeHostAction>(device, setting);
+        else if(type == "switchprofile")
+            return std::make_shared<SwitchProfileAction>(device, setting);
         else
             throw InvalidAction(type);
 

--- a/src/logid/actions/SwitchProfileAction.cpp
+++ b/src/logid/actions/SwitchProfileAction.cpp
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2019-2020 PixlOne
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#include "SwitchProfileAction.h"
+#include "../util/log.h"
+#include "../backend/hidpp20/features/ReprogControls.h"
+
+logid::actions::SwitchProfileAction::SwitchProfileAction(logid::Device *device, libconfig::Setting &config) : Action(device), _config(device, config) {
+
+}
+
+void logid::actions::SwitchProfileAction::press() {
+    _pressed = true;
+    auto switchType = _config.getSwitchType();
+    if(switchType == Config::SwitchType_NEXT){
+
+    }
+    else if(switchType == Config::SwitchType_PREVIOUS){
+
+    }
+    else if(switchType == Config::SwitchType_DIRECT){
+
+    }
+}
+
+void logid::actions::SwitchProfileAction::release() {
+    _pressed = false;
+}
+
+uint8_t logid::actions::SwitchProfileAction::reprogFlags() const {
+    return backend::hidpp20::ReprogControls::TemporaryDiverted;;
+}
+
+logid::actions::SwitchProfileAction::Config::Config(logid::Device *device, libconfig::Setting &config) : Action::Config(device){
+    if(!config.isGroup()) {
+        logPrintf(WARN, "Line %d: action must be an object, skipping.",
+                  config.getSourceLine());
+        return;
+    }
+
+    _switchType = SwitchType_UNKNOWN;
+    try {
+        auto &type = config.lookup("type");
+        if(type.getType() == libconfig::Setting::TypeString){
+            std::string typestr = type;
+            if(typestr == "next"){
+                _switchType = SwitchType_NEXT;
+            }
+            else if(typestr == "prev"){
+                _switchType = SwitchType_PREVIOUS;
+            }
+            else if(typestr == "direct"){
+                try {
+                    auto &profid = config.lookup("profile");
+                    if(profid.isNumber()){
+                        _directProfileID = profid;
+                        _switchType = SwitchType_DIRECT;
+                    }
+                    else{
+                        logPrintf(WARN, "Line %d: profile was not a number, skipping.",
+                                  config.getSourceLine());
+                        return;
+                    }
+                } catch (libconfig::SettingNotFoundException& e) {
+                    logPrintf(WARN, "Line %d: profile is a required field with direct type, skipping.",
+                              config.getSourceLine());
+                    return;
+                }
+            }
+            else{
+                logPrintf(WARN, "Line %d: %s is unknown profile switch type, skipping.",
+                          config.getSourceLine(), typestr.c_str());
+                return;
+            }
+        }
+        else{
+            logPrintf(WARN, "Line %d: type is not string, skipping.",
+                      config.getSourceLine());
+            return;
+        }
+    } catch (libconfig::SettingNotFoundException& e) {
+        logPrintf(WARN, "Line %d: type is a required field, skipping.",
+                  config.getSourceLine());
+    }
+}
+
+logid::actions::SwitchProfileAction::Config::SwitchType
+logid::actions::SwitchProfileAction::Config::getSwitchType() const {
+    return _switchType;
+}
+
+int logid::actions::SwitchProfileAction::Config::getDirectProfileId() const {
+    return _directProfileID;
+}
+
+
+
+

--- a/src/logid/actions/SwitchProfileAction.cpp
+++ b/src/logid/actions/SwitchProfileAction.cpp
@@ -54,7 +54,7 @@ logid::actions::SwitchProfileAction::Config::Config(logid::Device *device, libco
 
     _switchType = SwitchType_UNKNOWN;
     try {
-        auto &type = config.lookup("type");
+        auto &type = config.lookup("switchtype");
         if(type.getType() == libconfig::Setting::TypeString){
             std::string typestr = type;
             if(typestr == "next"){
@@ -76,7 +76,7 @@ logid::actions::SwitchProfileAction::Config::Config(logid::Device *device, libco
                         return;
                     }
                 } catch (libconfig::SettingNotFoundException& e) {
-                    logPrintf(WARN, "Line %d: profile is a required field with direct type, skipping.",
+                    logPrintf(WARN, "Line %d: profile is a required field with direct switchtype, skipping.",
                               config.getSourceLine());
                     return;
                 }
@@ -88,12 +88,12 @@ logid::actions::SwitchProfileAction::Config::Config(logid::Device *device, libco
             }
         }
         else{
-            logPrintf(WARN, "Line %d: type is not string, skipping.",
+            logPrintf(WARN, "Line %d: switchtype is not string, skipping.",
                       config.getSourceLine());
             return;
         }
     } catch (libconfig::SettingNotFoundException& e) {
-        logPrintf(WARN, "Line %d: type is a required field, skipping.",
+        logPrintf(WARN, "Line %d: switchtype is a required field, skipping.",
                   config.getSourceLine());
     }
 }

--- a/src/logid/actions/SwitchProfileAction.cpp
+++ b/src/logid/actions/SwitchProfileAction.cpp
@@ -18,22 +18,31 @@
 #include "SwitchProfileAction.h"
 #include "../util/log.h"
 #include "../backend/hidpp20/features/ReprogControls.h"
+#include "../Device.h"
 
-logid::actions::SwitchProfileAction::SwitchProfileAction(logid::Device *device, libconfig::Setting &config) : Action(device), _config(device, config) {
+logid::actions::SwitchProfileAction::SwitchProfileAction(logid::Device *device, libconfig::Setting &config) : Action(device), _config(device, config),
+                                                                                        remapfeat(nullptr)
+{
 
 }
 
 void logid::actions::SwitchProfileAction::press() {
     _pressed = true;
+
+    if(remapfeat == nullptr){
+        remapfeat = _device->getFeature<features::RemapButton>("remapbutton");
+    }
+
     auto switchType = _config.getSwitchType();
     if(switchType == Config::SwitchType_NEXT){
-
+        remapfeat->nextProfile();
     }
     else if(switchType == Config::SwitchType_PREVIOUS){
-
+        remapfeat->prevProfile();
     }
     else if(switchType == Config::SwitchType_DIRECT){
-
+        int nextprofind = _config.getDirectProfileId();
+        remapfeat->setProfile(nextprofind);
     }
 }
 

--- a/src/logid/actions/SwitchProfileAction.h
+++ b/src/logid/actions/SwitchProfileAction.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019-2020 PixlOne
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#ifndef LOGID_ACTION_SWITCHPROFILE_H
+#define LOGID_ACTION_SWITCHPROFILE_H
+
+#include <vector>
+#include <libconfig.h++>
+#include "Action.h"
+
+namespace logid {
+    namespace actions
+    {
+        /**
+         * @brief class that represents an action to switch device profile
+         */
+        class SwitchProfileAction : public Action
+        {
+        public:
+            SwitchProfileAction(Device* device, libconfig::Setting& config);
+
+            virtual void press();
+            virtual void release();
+
+            virtual uint8_t reprogFlags() const;
+
+            class Config : public Action::Config
+            {
+            public:
+                explicit Config(Device* device, libconfig::Setting& root);
+                enum SwitchType{
+                    SwitchType_UNKNOWN = 0,
+                    SwitchType_NEXT,
+                    SwitchType_PREVIOUS,
+                    SwitchType_DIRECT
+                };
+                SwitchType getSwitchType() const;
+                int getDirectProfileId() const;
+            protected:
+                /**
+                 * @brief enum value describing what kind of profile switch it is
+                 */
+                SwitchType _switchType;
+                /**
+                 * @brief int describing what profile to switch to if switchType == SwitchType_DIRECT
+                 */
+                int _directProfileID = 0;
+            };
+
+        protected:
+            Config _config;
+        };
+    }}
+
+
+#endif //LOGIOPS_SWITCHPROFILEACTION_H

--- a/src/logid/actions/SwitchProfileAction.h
+++ b/src/logid/actions/SwitchProfileAction.h
@@ -21,6 +21,7 @@
 #include <vector>
 #include <libconfig.h++>
 #include "Action.h"
+#include "../features/RemapButton.h"
 
 namespace logid {
     namespace actions
@@ -63,6 +64,7 @@ namespace logid {
 
         protected:
             Config _config;
+            std::shared_ptr<features::RemapButton> remapfeat;
         };
     }}
 

--- a/src/logid/features/RemapButton.h
+++ b/src/logid/features/RemapButton.h
@@ -33,15 +33,24 @@ namespace features
         virtual void configure();
         virtual void listen();
 
+        void nextProfile();
+        void prevProfile();
+        void setProfile(int profileIndex);
         class Config : public DeviceFeature::Config
         {
         public:
             explicit Config(Device* dev);
             const std::map<uint8_t, std::shared_ptr<actions::Action>>&
                 buttons();
+            int getProfileCount();
+            void setProfile(int profileIndex);
+
+            int getCurrentProfile() const;
+
         protected:
-            void _parseButton(libconfig::Setting& setting);
-            std::map<uint8_t, std::shared_ptr<actions::Action>> _buttons;
+            void _parseButton(libconfig::Setting& setting, int profileind);
+            std::vector<std::map<uint8_t, std::shared_ptr<actions::Action>>> _buttons;
+            int _currentProfile = 0;
         };
     private:
         void _buttonEvent(const std::set<uint16_t>& new_state);


### PR DESCRIPTION
added a very simple profile system for button remapings, as well as adding an action that can switch between the profiles.

the way one creates another profile is by instead of having the buttons be a list of objects, they are now a list of lists of objects.
thereby one sublist inside the buttons list is one profile. one can then switch between them by executing the "switchprofile" action with "switchtype" either set to "next", "prev" or "direct". if switchtype == direct then the action will switch to the profile that is at the index specified by setting the "profile" variable in the action. 

this implementation also works with the old list of objects type of config, but then just has one profile. 