### PR TITLE
Fix logid.example.cfg file

### DIFF
--- a/logid.example.cfg
+++ b/logid.example.cfg
@@ -55,10 +55,6 @@ devices: (
                         {
                             type = "ToggleSmartshift";
                         }
-                    },
-                    {
-                        direction: "None"
-                        mode: "NoPress"
                     }
                 );
             };


### PR DESCRIPTION
Hello,

First of all, I'd like to thank you for your great tool to use my MX Master 3 on my Arch Linux.
I'm using your lib through the AUR package https://aur.archlinux.org/packages/logiops.

While I was trying to configure it, I got the following message when I checked the status of my configuration based on your example config file:

```bash
sudo systemctl status logid.service                                                                                                                                                                       superitman@desktop
● logid.service - Logitech Configuration Daemon
     Loaded: loaded (/usr/lib/systemd/system/logid.service; enabled; vendor preset: disabled)
     Active: active (running) since Tue 2020-08-25 23:02:16 CEST; 51s ago
   Main PID: 55250 (logid)
      Tasks: 9 (limit: 28745)
     Memory: 1.5M
     CGroup: /system.slice/logid.service
             └─55250 /usr/bin/logid

Aug 25 23:02:16 desktop systemd[1]: Started Logitech Configuration Daemon.
Aug 25 23:02:19 desktop logid[55250]: [WARN] Error adding device /dev/hidraw3: std::exception
Aug 25 23:02:20 desktop logid[55250]: [WARN] Error adding device /dev/hidraw7: std::exception
Aug 25 23:02:21 desktop logid[55250]: [WARN] Error adding device /dev/hidraw4: std::exception
Aug 25 23:02:22 desktop logid[55250]: [WARN] Line 59: action is a required field, skipping.
Aug 25 23:02:24 desktop logid[55250]: [WARN] Error adding device /dev/hidraw2: std::exception
```

Based on the error message, I understood that I cannot use the example file with the line 59:
https://github.com/PixlOne/logiops/blob/8348782f27ecc998ddc4f86a5a892d33a7f21672/logid.example.cfg#L59-L62

Since there is no action related to this direction, I think we could simply remove this gesture :blush: 

I tested with an MX Master 3 and without this gesture, everything is working fine :+1: 

Please let me know if you want I change something.

Kr,
Alexis