### PR TITLE
Add one click installer shell script for easy install.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ You may also refer to logid.example.cfg for an example.
 
 Default location for the configuration file is /etc/logid.cfg.
 
+## Install
+Run the included ```install.sh``` executable, or follow the below build instructions.
+
 ## Dependencies
 
 This project requires a C++14 compiler, cmake, libevdev, libudev, and libconfig. For popular distributions, I've included commands below.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You may also refer to logid.example.cfg for an example.
 Default location for the configuration file is /etc/logid.cfg.
 
 ## Install
-Run the included ```install.sh``` executable as root, or follow the below build instructions.
+Run the included ```install.sh``` executable from terminal, or follow the below build instructions.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You may also refer to logid.example.cfg for an example.
 Default location for the configuration file is /etc/logid.cfg.
 
 ## Install
-Run the included ```install.sh``` executable, or follow the below build instructions.
+Run the included ```install.sh``` executable as root, or follow the below build instructions.
 
 ## Dependencies
 

--- a/install.sh
+++ b/install.sh
@@ -4,24 +4,28 @@ echo "Installing logiops by PixlOne..."
 # Check sudo privileges:
 if [ `id | sed -e 's/(.*//'` != "uid=0" ]; then
   echo "You need superuser privileges to run this install script, please run as superuser."
+  echo "Exiting..."
   exit 1
 fi
 
 # Install dependencies:
 if [ -d "/etc/apt" ]; then
-  apt install -y cmake libevdev-dev libudev-dev libconfig++-dev
+  apt install -y g++ cmake libevdev-dev libudev-dev libconfig++-dev
 elif [ -f "/etc/arch-release" ]; then
-  pacman -S cmake libevdev libconfig pkgconf
+  pacman -S g++ cmake libevdev libconfig pkgconf
 else
   echo "Install failed: System is not Debian or Arch."
+  echo "Exiting..."
   exit 1
 fi
 
 # Build
+echo "Building program..."
 if [ `echo $?` = "0" ]; then
   mkdir -p build
 else
   echo "Dependencies installation failed."
+  echo "Exiting..."
   exit 1
 fi
 
@@ -32,6 +36,7 @@ if [ `echo $?` = "0" ]; then
   make install
 else
   echo "Make failed."
+  echo "Exiting..."
   exit 1
 fi
 
@@ -39,12 +44,14 @@ fi
 systemctl enable logid
 systemctl start logid
 
-# Print device name
-echo "Your device name: "
-logid -v
 touch /etc/logid.cfg
 
 # Finish up
 echo "-------------------------"
 echo "Install complete!"
+echo "-------------------------"
 echo "Go to /etc/logid.cfg to configure your mouse settings. Examples here: https://wiki.archlinux.org/index.php/Logitech_MX_Master"
+# Print device name
+echo "Your mouse name: "
+logid -v
+exit 0

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+echo "Installing logiops by PixlOne..."
+
+# Check sudo privileges:
+if [ `id | sed -e 's/(.*//'` != "uid=0" ]; then
+  echo "You need superuser privileges to run this install script, please run as superuser."
+  exit 1
+fi
+
+# Install dependencies:
+if [ -d "/etc/apt" ]; then
+  apt install -y cmake libevdev-dev libudev-dev libconfig++-dev
+elif [ -f "/etc/arch-release" ]; then
+  pacman -S cmake libevdev libconfig pkgconf
+else
+  echo "Install failed: System is not Debian or Arch."
+  exit 1
+fi
+
+# Build
+if [ `echo $?` = "0" ]; then
+  mkdir -p build
+else
+  echo "Dependencies installation failed."
+  exit 1
+fi
+
+cd build
+cmake ..
+make
+if [ `echo $?` = "0" ]; then
+  make install
+else
+  echo "Make failed."
+  exit 1
+fi
+
+# Start, autostart
+systemctl enable logid
+systemctl start logid
+
+# Print device name
+echo "Your device name: "
+logid -v
+touch /etc/logid.cfg
+
+# Finish up
+echo "-------------------------"
+echo "Install complete!"
+echo "Go to /etc/logid.cfg to configure your mouse settings. Examples here: https://wiki.archlinux.org/index.php/Logitech_MX_Master"

--- a/install.sh
+++ b/install.sh
@@ -4,18 +4,21 @@ echo "\n-------------------------\n"
 
 # Install dependencies:
 echo "Installing dependencies..."
-if [ -d "/etc/apt" ]; then
+if [ -x "$(command -v apt)" ]; then
   sudo apt install -y g++ cmake libevdev-dev libudev-dev libconfig++-dev
-elif [ -f "/etc/arch-release" ]; then
+elif [ -x "$(command -v pacman)" ]; then
   sudo pacman -S g++ cmake libevdev libconfig pkgconf
+elif [ -x "$(command -v yum)" ]; then
+  sudo yum -y install cmake libevdev-devel libudev-devel libconfig-devel
 else
-  echo "Install failed: System is not Debian or Arch. Exiting..."
+  echo "Install failed: Package manager not supported."
+  echo "Please build logiops manually. Exiting..."
   exit 1
 fi
 
 # Build
 echo "\n-------------------------\n"
-echo "Building program..."
+echo "Building logiops..."
 if [ `echo $?` = "0" ]; then
   mkdir -p build
 else

--- a/install.sh
+++ b/install.sh
@@ -1,59 +1,56 @@
 #!/bin/sh
 echo "Installing logiops by PixlOne..."
-
-# Check sudo privileges:
-if [ `id | sed -e 's/(.*//'` != "uid=0" ]; then
-  echo "You need superuser privileges to run this install script, please run as superuser."
-  echo "Exiting..."
-  exit 1
-fi
+echo "\n-------------------------\n"
 
 # Install dependencies:
 echo "Installing dependencies..."
 if [ -d "/etc/apt" ]; then
-  apt install -y g++ cmake libevdev-dev libudev-dev libconfig++-dev
+  sudo apt install -y g++ cmake libevdev-dev libudev-dev libconfig++-dev
 elif [ -f "/etc/arch-release" ]; then
-  pacman -S g++ cmake libevdev libconfig pkgconf
+  sudo pacman -S g++ cmake libevdev libconfig pkgconf
 else
-  echo "Install failed: System is not Debian or Arch."
-  echo "Exiting..."
+  echo "Install failed: System is not Debian or Arch. Exiting..."
   exit 1
 fi
 
 # Build
+echo "\n-------------------------\n"
 echo "Building program..."
 if [ `echo $?` = "0" ]; then
   mkdir -p build
 else
-  echo "Dependencies installation failed."
-  echo "Exiting..."
+  echo "Dependencies installation failed. Exiting..."
   exit 1
 fi
 
 cd build
 cmake ..
 make
+
 if [ `echo $?` = "0" ]; then
-  make install
+  sudo make install
 else
-  echo "Make failed."
-  echo "Exiting..."
+  echo "Make failed. Exiting..."
   exit 1
 fi
 
 # Start, autostart
-systemctl enable logid
-systemctl start logid
+echo "\n-------------------------\n"
+echo "Setting up logid to autostart on boot..."
+sudo systemctl enable logid
+sudo systemctl start logid
 
 # Config file
-touch /etc/logid.cfg
+echo "\n-------------------------\n"
+echo "Creating config file..."
+sudo touch /etc/logid.cfg
 
 # Finish up
-echo "-------------------------"
+echo "\n-------------------------\n"
 echo "Install complete!"
-echo "-------------------------"
-echo "Go to /etc/logid.cfg to configure your mouse settings. Examples here: https://wiki.archlinux.org/index.php/Logitech_MX_Master"
-# Print device name
-echo "Your mouse name: "
-logid -v
-exec bash
+echo "Run logid -v to check your device name, then go to /etc/logid.cfg to configure your mouse settings."
+echo "Detailed instructions and examples here: https://wiki.archlinux.org/index.php/Logitech_MX_Master"
+echo "\n-------------------------\n"
+echo "Press enter to finish..."
+read nothing
+exit 0

--- a/install.sh
+++ b/install.sh
@@ -9,6 +9,7 @@ if [ `id | sed -e 's/(.*//'` != "uid=0" ]; then
 fi
 
 # Install dependencies:
+echo "Installing dependencies..."
 if [ -d "/etc/apt" ]; then
   apt install -y g++ cmake libevdev-dev libudev-dev libconfig++-dev
 elif [ -f "/etc/arch-release" ]; then
@@ -44,6 +45,7 @@ fi
 systemctl enable logid
 systemctl start logid
 
+# Config file
 touch /etc/logid.cfg
 
 # Finish up
@@ -54,4 +56,4 @@ echo "Go to /etc/logid.cfg to configure your mouse settings. Examples here: http
 # Print device name
 echo "Your mouse name: "
 logid -v
-exit 0
+exec bash


### PR DESCRIPTION
Installing this program used to take a lot of setting up (due to complicated dependencies and documentations not up to date, which has since been fixed). It still takes a few more commands to set up than I'd like, so I've made a shell script to speed up installing this each time I set up new systems. I am new at this, so apologies and please advice if I did something wrong. 

The shell script is tested with Linux Mint 19.3 and Linux Mint 20 (Debian, Ubuntu 18.10, Ubuntu 20.04). Untested with Arch.