### PR TITLE
Adding MX Anywhere 2 to TESTED.md

### DIFF
--- a/TESTED.md
+++ b/TESTED.md
@@ -7,6 +7,7 @@ This is not by any means an exhaustive list. Many more devices are supported but
 |  MX Master 3   |     Yes     |      `Wireless Mouse MX Master 3`      |
 |  MX Master 2S  |     Yes     |     `Wireless Mouse MX Master 2S`      |
 |   MX Master    |     Yes     |       `Wireless Mouse MX Master`       |
+| MX Anywhere 2  |     Yes     | `Wireless Mobile Mouse MX Anywhere 2`  |
 | MX Anywhere S2 |     Yes     | `Wireless Mobile Mouse MX Anywhere 2S` |
 | MX Anywhere 3  |     Yes     |            `MX Anywhere 3`             |
 |  MX Vertical   |     Yes     |                                        |


### PR DESCRIPTION
Tested and working on Arch/Manjaro and Fedora 33 with both Bluetooth and Unifying Receiver. Slightly different name to 2S, hence the addition.