### PR TITLE
Added Fedora 33 dependancy install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This project requires a C++14 compiler, `cmake`, `libevdev`, `libudev`, and `lib
 
 **Solus:** `sudo eopkg install libevdev-devel libconfig-devel libgudev-devel`
 
-**Fedora:** `sudo dnf install cmake libevdev-devel systemd-devel1 libconfig-devel gcc-c++`
+**Fedora:** `sudo dnf install cmake libevdev-devel systemd-devel libconfig-devel gcc-c++`
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This project requires a C++14 compiler, `cmake`, `libevdev`, `libudev`, and `lib
 
 **Solus:** `sudo eopkg install libevdev-devel libconfig-devel libgudev-devel`
 
-**Fedora 33:** `sudo dnf install cmake libevdev-devel systemd-devel1 libconfig-devel gcc-c++`
+**Fedora:** `sudo dnf install cmake libevdev-devel systemd-devel1 libconfig-devel gcc-c++`
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ This project requires a C++14 compiler, `cmake`, `libevdev`, `libudev`, and `lib
 
 **Solus:** `sudo eopkg install libevdev-devel libconfig-devel libgudev-devel`
 
+**Fedora 33:** `sudo dnf install cmake libevdev-devel systemd-devel1 libconfig-devel gcc-c++`
+
 ## Building
 
 To build this project, run:


### PR DESCRIPTION
Tested on a relatively fresh install of Fedora 33, gcc-c++ included as no c++ compiler by default, feel free to remove if it fits better with the pattern of not including one in the previous instructions, however it did trip me up for a few minutes so may be worth leaving in.