### PR TITLE
Enable compatibility with libconfig older than v1.5

### DIFF
--- a/src/logid/Configuration.cpp
+++ b/src/logid/Configuration.cpp
@@ -98,7 +98,7 @@ Configuration::Configuration(const std::string& config_file)
     }
 
     try {
-        auto& ignore = root.lookup("ignore");
+        auto& ignore = root["ignore"];
         if(ignore.getType() == libconfig::Setting::TypeInt) {
             _ignore_list.insert((int)ignore);
         } else if(ignore.isList() || ignore.isArray()) {
@@ -116,7 +116,7 @@ Configuration::Configuration(const std::string& config_file)
     } catch(const SettingNotFoundException& e) {
         // May be called blacklist
         try {
-            auto& ignore = root.lookup("blacklist");
+            auto& ignore = root["blacklist"];
             if(ignore.getType() == libconfig::Setting::TypeInt) {
                 _ignore_list.insert((int)ignore);
             } else if(ignore.isList() || ignore.isArray()) {

--- a/src/logid/actions/Action.cpp
+++ b/src/logid/actions/Action.cpp
@@ -41,7 +41,7 @@ std::shared_ptr<Action> Action::makeAction(Device *device, libconfig::Setting
     }
 
     try {
-        auto& action_type = setting.lookup("type");
+        auto& action_type = setting["type"];
 
         if(action_type.getType() != libconfig::Setting::TypeString) {
             logPrintf(WARN, "Line %d: Action type must be a string",

--- a/src/logid/actions/ChangeDPI.cpp
+++ b/src/logid/actions/ChangeDPI.cpp
@@ -77,7 +77,7 @@ ChangeDPI::Config::Config(Device *device, libconfig::Setting &config) :
     }
 
     try {
-        auto& inc = config.lookup("inc");
+        auto& inc = config["inc"];
         if(inc.getType() != libconfig::Setting::TypeInt)
             logPrintf(WARN, "Line %d: inc must be an integer",
                       inc.getSourceLine());
@@ -88,7 +88,7 @@ ChangeDPI::Config::Config(Device *device, libconfig::Setting &config) :
     }
 
     try {
-        auto& sensor = config.lookup("sensor");
+        auto& sensor = config["sensor"];
         if(sensor.getType() != libconfig::Setting::TypeInt)
             logPrintf(WARN, "Line %d: sensor must be an integer",
                       sensor.getSourceLine());

--- a/src/logid/actions/ChangeHostAction.cpp
+++ b/src/logid/actions/ChangeHostAction.cpp
@@ -62,7 +62,7 @@ ChangeHostAction::Config::Config(Device *device, libconfig::Setting& config)
     : Action::Config(device)
 {
     try {
-        auto& host = config.lookup("host");
+        auto& host = config["host"];
         if(host.getType() == libconfig::Setting::TypeInt) {
             _offset = false;
             _host = host;

--- a/src/logid/actions/CycleDPI.cpp
+++ b/src/logid/actions/CycleDPI.cpp
@@ -77,7 +77,7 @@ CycleDPI::Config::Config(Device *device, libconfig::Setting &config) :
     }
 
     try {
-        auto& sensor = config.lookup("sensor");
+        auto& sensor = config["sensor"];
         if(sensor.getType() != Setting::TypeInt)
             logPrintf(WARN, "Line %d: sensor must be an integer",
                     sensor.getSourceLine());
@@ -87,7 +87,7 @@ CycleDPI::Config::Config(Device *device, libconfig::Setting &config) :
     }
 
     try {
-        auto& dpis = config.lookup("dpis");
+        auto& dpis = config["dpis"];
         if(!dpis.isList() && !dpis.isArray()) {
             logPrintf(WARN, "Line %d: dpis must be a list or array, skipping.",
                     dpis.getSourceLine());

--- a/src/logid/actions/GestureAction.cpp
+++ b/src/logid/actions/GestureAction.cpp
@@ -180,7 +180,7 @@ GestureAction::Config::Config(Device* device, libconfig::Setting &root) :
     Action::Config(device)
 {
     try {
-        auto& gestures = root.lookup("gestures");
+        auto& gestures = root["gestures"];
 
         if(!gestures.isList()) {
             logPrintf(WARN, "Line %d: gestures must be a list, ignoring.",
@@ -199,7 +199,7 @@ GestureAction::Config::Config(Device* device, libconfig::Setting &root) :
 
             Direction d;
             try {
-                auto& direction = gestures[i].lookup("direction");
+                auto& direction = gestures[i]["direction"];
                 if(direction.getType() != libconfig::Setting::TypeString) {
                     logPrintf(WARN, "Line %d: direction must be a string, "
                                     "skipping.", direction.getSourceLine());
@@ -228,7 +228,7 @@ GestureAction::Config::Config(Device* device, libconfig::Setting &root) :
 
             if(d == None) {
                 try {
-                    auto& mode = gestures[i].lookup("mode");
+                    auto& mode = gestures[i]["mode"];
                     if(mode.getType() == libconfig::Setting::TypeString) {
                         std::string mode_str = mode;
                         std::transform(mode_str.begin(), mode_str.end(),
@@ -251,10 +251,10 @@ GestureAction::Config::Config(Device* device, libconfig::Setting &root) :
 
                 try {
                     _none_action = Action::makeAction(_device,
-                            gestures[i].lookup("action"));
+                            gestures[i]["action"]);
                 } catch (InvalidAction& e) {
                     logPrintf(WARN, "Line %d: %s is not a valid action, "
-                                    "skipping.", gestures[i].lookup("action")
+                                    "skipping.", gestures[i]["action"]
                                     .getSourceLine(), e.what());
                 } catch (libconfig::SettingNotFoundException& e) {
                     logPrintf(WARN, "Line %d: action is a required field, "

--- a/src/logid/actions/KeypressAction.cpp
+++ b/src/logid/actions/KeypressAction.cpp
@@ -57,7 +57,7 @@ KeypressAction::Config::Config(Device* device, libconfig::Setting& config) :
     }
 
     try {
-        auto &keys = config.lookup("keys");
+        auto &keys = config["keys"];
         if(keys.isArray() || keys.isList()) {
             int key_count = keys.getLength();
             for(int i = 0; i < key_count; i++) {

--- a/src/logid/actions/gesture/AxisGesture.cpp
+++ b/src/logid/actions/gesture/AxisGesture.cpp
@@ -101,7 +101,7 @@ AxisGesture::Config::Config(Device *device, libconfig::Setting &setting) :
     Gesture::Config(device, setting, false)
 {
     try {
-        auto& axis = setting.lookup("axis");
+        auto& axis = setting["axis"];
         if(axis.isNumber()) {
             _axis = axis;
         } else if(axis.getType() == libconfig::Setting::TypeString) {
@@ -123,7 +123,7 @@ AxisGesture::Config::Config(Device *device, libconfig::Setting &setting) :
     }
 
     try {
-        auto& multiplier = setting.lookup("axis_multiplier");
+        auto& multiplier = setting["axis_multiplier"];
         if(multiplier.isNumber()) {
             if(multiplier.getType() == libconfig::Setting::TypeFloat)
                 _multiplier = multiplier;

--- a/src/logid/actions/gesture/Gesture.cpp
+++ b/src/logid/actions/gesture/Gesture.cpp
@@ -38,7 +38,7 @@ Gesture::Config::Config(Device* device, libconfig::Setting& root,
     if(action_required) {
         try {
             _action = Action::makeAction(_device,
-                                         root.lookup("action"));
+                                         root["action"]);
         } catch (libconfig::SettingNotFoundException &e) {
             throw InvalidGesture("action is missing");
         }
@@ -49,7 +49,7 @@ Gesture::Config::Config(Device* device, libconfig::Setting& root,
 
     _threshold = LOGID_GESTURE_DEFAULT_THRESHOLD;
     try {
-        auto& threshold = root.lookup("threshold");
+        auto& threshold = root["threshold"];
         if(threshold.getType() == libconfig::Setting::TypeInt) {
             _threshold = (int)threshold;
             if(_threshold <= 0) {
@@ -76,7 +76,7 @@ std::shared_ptr<Gesture> Gesture::makeGesture(Device *device,
     }
 
     try {
-        auto& gesture_mode = setting.lookup("mode");
+        auto& gesture_mode = setting["mode"];
 
         if(gesture_mode.getType() != libconfig::Setting::TypeString) {
             logPrintf(WARN, "Line %d: Gesture mode must be a string,"

--- a/src/logid/actions/gesture/IntervalGesture.cpp
+++ b/src/logid/actions/gesture/IntervalGesture.cpp
@@ -66,7 +66,7 @@ IntervalGesture::Config::Config(Device *device, libconfig::Setting &setting) :
     Gesture::Config(device, setting)
 {
     try {
-        auto& interval = setting.lookup("interval");
+        auto& interval = setting["interval"];
         if(interval.getType() != libconfig::Setting::TypeInt) {
             logPrintf(WARN, "Line %d: interval must be an integer, skipping.",
                     interval.getSourceLine());
@@ -76,7 +76,7 @@ IntervalGesture::Config::Config(Device *device, libconfig::Setting &setting) :
     } catch(libconfig::SettingNotFoundException& e) {
         try {
             // pixels is an alias for interval
-            auto& interval = setting.lookup("pixels");
+            auto& interval = setting["pixels"];
             if(interval.getType() != libconfig::Setting::TypeInt) {
                 logPrintf(WARN, "Line %d: pixels must be an integer, skipping.",
                           interval.getSourceLine());

--- a/src/logid/features/HiresScroll.cpp
+++ b/src/logid/features/HiresScroll.cpp
@@ -157,7 +157,7 @@ HiresScroll::Config::Config(Device *dev) : DeviceFeature::Config(dev)
         _mode = 0;
         _mask = 0;
         try {
-            auto& hires = config_root.lookup("hires");
+            auto& hires = config_root["hires"];
             if(hires.getType() == libconfig::Setting::TypeBoolean) {
                 _mask |= hidpp20::HiresScroll::Mode::HiRes;
                 if(hires)
@@ -169,7 +169,7 @@ HiresScroll::Config::Config(Device *dev) : DeviceFeature::Config(dev)
         } catch(libconfig::SettingNotFoundException& e) { }
 
         try {
-            auto& invert = config_root.lookup("invert");
+            auto& invert = config_root["invert"];
             if(invert.getType() == libconfig::Setting::TypeBoolean) {
                 _mask |= hidpp20::HiresScroll::Mode::Inverted;
                 if(invert)
@@ -181,7 +181,7 @@ HiresScroll::Config::Config(Device *dev) : DeviceFeature::Config(dev)
         } catch(libconfig::SettingNotFoundException& e) { }
 
         try {
-            auto& target = config_root.lookup("target");
+            auto& target = config_root["target"];
             if(target.getType() == libconfig::Setting::TypeBoolean) {
                 _mask |= hidpp20::HiresScroll::Mode::Target;
                 if(target)
@@ -194,7 +194,7 @@ HiresScroll::Config::Config(Device *dev) : DeviceFeature::Config(dev)
 
         if(_mode & hidpp20::HiresScroll::Mode::Target) {
             try {
-                auto& up = config_root.lookup("up");
+                auto& up = config_root["up"];
                 try {
                     auto g = actions::Gesture::makeGesture(dev, up);
                     if(g->wheelCompatibility()) {
@@ -214,7 +214,7 @@ HiresScroll::Config::Config(Device *dev) : DeviceFeature::Config(dev)
             }
 
             try {
-                auto& down = config_root.lookup("down");
+                auto& down = config_root["down"];
                 try {
                     auto g = actions::Gesture::makeGesture(dev, down);
                     if(g->wheelCompatibility()) {

--- a/src/logid/features/RemapButton.cpp
+++ b/src/logid/features/RemapButton.cpp
@@ -178,7 +178,7 @@ void RemapButton::Config::_parseButton(libconfig::Setting &setting)
 
     uint16_t cid;
     try {
-        auto& cid_setting = setting.lookup("cid");
+        auto& cid_setting = setting["cid"];
         if(!cid_setting.isNumber()) {
             logPrintf(WARN, "Line %d: cid must be a number, ignoring.",
                     cid_setting.getSourceLine());
@@ -193,7 +193,7 @@ void RemapButton::Config::_parseButton(libconfig::Setting &setting)
 
     try {
         _buttons.emplace(cid, Action::makeAction(_device,
-                setting.lookup("action")));
+                setting["action"]));
     } catch(libconfig::SettingNotFoundException& e) {
         logPrintf(WARN, "Line %d: action is required, ignoring.",
                   setting.getSourceLine());

--- a/src/logid/features/ThumbWheel.cpp
+++ b/src/logid/features/ThumbWheel.cpp
@@ -184,7 +184,7 @@ ThumbWheel::Config::Config(Device* dev) : DeviceFeature::Config(dev)
         }
 
         try {
-            auto& divert = config_root.lookup("divert");
+            auto& divert = config_root["divert"];
             if(divert.getType() == libconfig::Setting::TypeBoolean) {
                 _divert = divert;
             } else {
@@ -194,7 +194,7 @@ ThumbWheel::Config::Config(Device* dev) : DeviceFeature::Config(dev)
         } catch(libconfig::SettingNotFoundException& e) { }
 
         try {
-            auto& invert = config_root.lookup("invert");
+            auto& invert = config_root["invert"];
             if(invert.getType() == libconfig::Setting::TypeBoolean) {
                 _invert = invert;
             } else {
@@ -227,7 +227,7 @@ std::shared_ptr<actions::Action> ThumbWheel::Config::_genAction(Device* dev,
         libconfig::Setting& config_root, const std::string& name)
 {
     try {
-        auto& a_group = config_root.lookup(name);
+        auto& a_group = config_root[name];
         try {
             return actions::Action::makeAction(dev, a_group);
         } catch(actions::InvalidAction& e) {
@@ -244,7 +244,7 @@ std::shared_ptr<actions::Gesture> ThumbWheel::Config::_genGesture(Device* dev,
         libconfig::Setting& config_root, const std::string& name)
 {
     try {
-        auto& g_group = config_root.lookup(name);
+        auto& g_group = config_root[name];
         try {
             auto g = actions::Gesture::makeGesture(dev, g_group);
             if(g->wheelCompatibility()) {


### PR DESCRIPTION
libconfig v1.4.9 is the latest version available in the RHEL / CentOS 7 repos, but `Setting.lookup()` was only added in v1.5.
This PR allows logiops to be compiled on these operating systems.