### PR TITLE
App switching support

### DIFF
--- a/src/logid/Configuration.cpp
+++ b/src/logid/Configuration.cpp
@@ -98,7 +98,7 @@ Configuration::Configuration(const std::string& config_file)
     }
 
     try {
-        auto& ignore = root.lookup("ignore");
+        auto& ignore = root["ignore"];
         if(ignore.getType() == libconfig::Setting::TypeInt) {
             _ignore_list.insert((int)ignore);
         } else if(ignore.isList() || ignore.isArray()) {
@@ -116,7 +116,7 @@ Configuration::Configuration(const std::string& config_file)
     } catch(const SettingNotFoundException& e) {
         // May be called blacklist
         try {
-            auto& ignore = root.lookup("blacklist");
+            auto& ignore = root["blacklist"];
             if(ignore.getType() == libconfig::Setting::TypeInt) {
                 _ignore_list.insert((int)ignore);
             } else if(ignore.isList() || ignore.isArray()) {

--- a/src/logid/actions/Action.cpp
+++ b/src/logid/actions/Action.cpp
@@ -41,7 +41,7 @@ std::shared_ptr<Action> Action::makeAction(Device *device, libconfig::Setting
     }
 
     try {
-        auto& action_type = setting.lookup("type");
+        auto& action_type = setting["type"];
 
         if(action_type.getType() != libconfig::Setting::TypeString) {
             logPrintf(WARN, "Line %d: Action type must be a string",

--- a/src/logid/actions/Action.h
+++ b/src/logid/actions/Action.h
@@ -49,6 +49,7 @@ namespace actions {
                 libconfig::Setting& setting);
 
         virtual void press() = 0;
+        virtual void secondaryRelease() {};
         virtual void release() = 0;
         virtual void move(int16_t x, int16_t y)
         {

--- a/src/logid/actions/Action.h
+++ b/src/logid/actions/Action.h
@@ -49,7 +49,7 @@ namespace actions {
                 libconfig::Setting& setting);
 
         virtual void press() = 0;
-        virtual void secondaryRelease() {};
+        virtual void halfRelease() {};
         virtual void release() = 0;
         virtual void move(int16_t x, int16_t y)
         {

--- a/src/logid/actions/ChangeDPI.cpp
+++ b/src/logid/actions/ChangeDPI.cpp
@@ -77,7 +77,7 @@ ChangeDPI::Config::Config(Device *device, libconfig::Setting &config) :
     }
 
     try {
-        auto& inc = config.lookup("inc");
+        auto& inc = config["inc"];
         if(inc.getType() != libconfig::Setting::TypeInt)
             logPrintf(WARN, "Line %d: inc must be an integer",
                       inc.getSourceLine());
@@ -88,7 +88,7 @@ ChangeDPI::Config::Config(Device *device, libconfig::Setting &config) :
     }
 
     try {
-        auto& sensor = config.lookup("sensor");
+        auto& sensor = config["sensor"];
         if(sensor.getType() != libconfig::Setting::TypeInt)
             logPrintf(WARN, "Line %d: sensor must be an integer",
                       sensor.getSourceLine());

--- a/src/logid/actions/ChangeHostAction.cpp
+++ b/src/logid/actions/ChangeHostAction.cpp
@@ -62,7 +62,7 @@ ChangeHostAction::Config::Config(Device *device, libconfig::Setting& config)
     : Action::Config(device)
 {
     try {
-        auto& host = config.lookup("host");
+        auto& host = config["host"];
         if(host.getType() == libconfig::Setting::TypeInt) {
             _offset = false;
             _host = host;

--- a/src/logid/actions/CycleDPI.cpp
+++ b/src/logid/actions/CycleDPI.cpp
@@ -77,7 +77,7 @@ CycleDPI::Config::Config(Device *device, libconfig::Setting &config) :
     }
 
     try {
-        auto& sensor = config.lookup("sensor");
+        auto& sensor = config["sensor"];
         if(sensor.getType() != Setting::TypeInt)
             logPrintf(WARN, "Line %d: sensor must be an integer",
                     sensor.getSourceLine());
@@ -87,7 +87,7 @@ CycleDPI::Config::Config(Device *device, libconfig::Setting &config) :
     }
 
     try {
-        auto& dpis = config.lookup("dpis");
+        auto& dpis = config["dpis"];
         if(!dpis.isList() && !dpis.isArray()) {
             logPrintf(WARN, "Line %d: dpis must be a list or array, skipping.",
                     dpis.getSourceLine());

--- a/src/logid/actions/GestureAction.cpp
+++ b/src/logid/actions/GestureAction.cpp
@@ -105,25 +105,33 @@ void GestureAction::release()
 
 void GestureAction::move(int16_t x, int16_t y)
 {
-    std::map<Direction, std::shared_ptr<Gesture>>::iterator gesture;
+    auto gesture = _config.gestures().end();
     int16_t axis = 0;
 
-    if (x < 0) {
+    bool isUp = _config.gestures().find(Up)->second->metThreshold();
+    bool isDown = _config.gestures().find(Down)->second->metThreshold();
+    bool isVertical = isUp || isDown;
+
+    bool isLeft = _config.gestures().find(Left)->second->metThreshold();
+    bool isRight = _config.gestures().find(Right)->second->metThreshold();
+    bool isHorizontal = isLeft || isRight;
+
+    if (!isVertical && x < 0) {
         gesture = _config.gestures().find(Left);
         axis = -x;
     }
 
-    if (x > 0) {
+    if (!isVertical && x > 0) {
         gesture = _config.gestures().find(Right);
         axis = x;
     }
 
-    if (y < 0) {
+    if (!isHorizontal && y < 0) {
         gesture = _config.gestures().find(Up);
         axis = -y;
     }
 
-    if (y > 0) {
+    if (!isHorizontal && y > 0) {
         gesture = _config.gestures().find(Down);
         axis = y;
     }

--- a/src/logid/actions/GestureAction.cpp
+++ b/src/logid/actions/GestureAction.cpp
@@ -105,69 +105,33 @@ void GestureAction::release()
 
 void GestureAction::move(int16_t x, int16_t y)
 {
-    auto new_x = _x + x, new_y = _y + y;
+    std::map<Direction, std::shared_ptr<Gesture>>::iterator gesture;
+    int16_t axis = 0;
 
-    if(abs(x) > 0) {
-        if(_x < 0 && new_x >= 0) { // Left -> Origin/Right
-            auto left = _config.gestures().find(Left);
-            if(left != _config.gestures().end())
-                left->second->move(_x);
-            if(new_x) { // Ignore to origin
-                auto right = _config.gestures().find(Right);
-                if(right != _config.gestures().end())
-                    right->second->move(new_x);
-            }
-        } else if(_x > 0 && new_x <= 0) { // Right -> Origin/Left
-            auto right = _config.gestures().find(Right);
-            if(right != _config.gestures().end())
-                right->second->move(-_x);
-            if(new_x) { // Ignore to origin
-                auto left = _config.gestures().find(Left);
-                if(left != _config.gestures().end())
-                    left->second->move(-new_x);
-            }
-        } else if(new_x < 0) { // Origin/Left to Left
-            auto left = _config.gestures().find(Left);
-            if(left != _config.gestures().end())
-                left->second->move(-x);
-        } else if(new_x > 0) { // Origin/Right to Right
-            auto right = _config.gestures().find(Right);
-            if(right != _config.gestures().end())
-                right->second->move(x);
-        }
+    if (x < 0) {
+        gesture = _config.gestures().find(Left);
+        axis = -x;
     }
 
-    if(abs(y) > 0) {
-        if(_y > 0 && new_y <= 0) { // Up -> Origin/Down
-            auto up = _config.gestures().find(Up);
-            if(up != _config.gestures().end())
-                up->second->move(_y);
-            if(new_y) { // Ignore to origin
-                auto down = _config.gestures().find(Down);
-                if(down != _config.gestures().end())
-                    down->second->move(new_y);
-            }
-        } else if(_y < 0 && new_y >= 0) { // Down -> Origin/Up
-            auto down = _config.gestures().find(Down);
-            if(down != _config.gestures().end())
-                down->second->move(-_y);
-            if(new_y) { // Ignore to origin
-                auto up = _config.gestures().find(Up);
-                if(up != _config.gestures().end())
-                    up->second->move(-new_y);
-            }
-        } else if(new_y < 0) { // Origin/Up to Up
-            auto up = _config.gestures().find(Up);
-            if(up != _config.gestures().end())
-                up->second->move(-y);
-        } else if(new_y > 0) {// Origin/Down to Down
-            auto down = _config.gestures().find(Down);
-            if(down != _config.gestures().end())
-                down->second->move(y);
-        }
+    if (x > 0) {
+        gesture = _config.gestures().find(Right);
+        axis = x;
     }
 
-    _x = new_x; _y = new_y;
+    if (y < 0) {
+        gesture = _config.gestures().find(Up);
+        axis = -y;
+    }
+
+    if (y > 0) {
+        gesture = _config.gestures().find(Down);
+        axis = y;
+    }
+
+    if (gesture != _config.gestures().end())
+        gesture->second->move(axis);
+
+    _x += x; _y += y;
 }
 
 uint8_t GestureAction::reprogFlags() const

--- a/src/logid/actions/GestureAction.cpp
+++ b/src/logid/actions/GestureAction.cpp
@@ -180,7 +180,7 @@ GestureAction::Config::Config(Device* device, libconfig::Setting &root) :
     Action::Config(device)
 {
     try {
-        auto& gestures = root.lookup("gestures");
+        auto& gestures = root["gestures"];
 
         if(!gestures.isList()) {
             logPrintf(WARN, "Line %d: gestures must be a list, ignoring.",
@@ -199,7 +199,7 @@ GestureAction::Config::Config(Device* device, libconfig::Setting &root) :
 
             Direction d;
             try {
-                auto& direction = gestures[i].lookup("direction");
+                auto& direction = gestures[i]["direction"];
                 if(direction.getType() != libconfig::Setting::TypeString) {
                     logPrintf(WARN, "Line %d: direction must be a string, "
                                     "skipping.", direction.getSourceLine());
@@ -228,7 +228,7 @@ GestureAction::Config::Config(Device* device, libconfig::Setting &root) :
 
             if(d == None) {
                 try {
-                    auto& mode = gestures[i].lookup("mode");
+                    auto& mode = gestures[i]["mode"];
                     if(mode.getType() == libconfig::Setting::TypeString) {
                         std::string mode_str = mode;
                         std::transform(mode_str.begin(), mode_str.end(),
@@ -251,10 +251,10 @@ GestureAction::Config::Config(Device* device, libconfig::Setting &root) :
 
                 try {
                     _none_action = Action::makeAction(_device,
-                            gestures[i].lookup("action"));
+                            gestures[i]["action"]);
                 } catch (InvalidAction& e) {
                     logPrintf(WARN, "Line %d: %s is not a valid action, "
-                                    "skipping.", gestures[i].lookup("action")
+                                    "skipping.", gestures[i]["action"]
                                     .getSourceLine(), e.what());
                 } catch (libconfig::SettingNotFoundException& e) {
                     logPrintf(WARN, "Line %d: action is a required field, "

--- a/src/logid/actions/GestureAction.h
+++ b/src/logid/actions/GestureAction.h
@@ -37,7 +37,7 @@ namespace actions {
             Right
         };
         static Direction toDirection(std::string direction);
-        static Direction toDirection(int16_t x, int16_t y);
+        Direction toDirection(int16_t x, int16_t y);
 
         GestureAction(Device* dev, libconfig::Setting& config);
 
@@ -59,6 +59,9 @@ namespace actions {
         };
 
     protected:
+        bool isVertical();
+        bool isHorizontal();
+
         int16_t _x, _y;
         Config _config;
     };

--- a/src/logid/actions/KeypressAction.cpp
+++ b/src/logid/actions/KeypressAction.cpp
@@ -35,6 +35,18 @@ void KeypressAction::press()
         virtual_input->pressKey(key);
 }
 
+void KeypressAction::secondaryRelease()
+{
+    bool skippedFirst = false;
+    for(auto& key : _config.keys()) {
+        if (!skippedFirst) {
+            skippedFirst = true;
+            continue;
+        }
+        virtual_input->releaseKey(key);
+    }
+}
+
 void KeypressAction::release()
 {
     _pressed = false;

--- a/src/logid/actions/KeypressAction.cpp
+++ b/src/logid/actions/KeypressAction.cpp
@@ -35,7 +35,7 @@ void KeypressAction::press()
         virtual_input->pressKey(key);
 }
 
-void KeypressAction::secondaryRelease()
+void KeypressAction::halfRelease()
 {
     bool skippedFirst = false;
     for(auto& key : _config.keys()) {

--- a/src/logid/actions/KeypressAction.cpp
+++ b/src/logid/actions/KeypressAction.cpp
@@ -57,7 +57,7 @@ KeypressAction::Config::Config(Device* device, libconfig::Setting& config) :
     }
 
     try {
-        auto &keys = config.lookup("keys");
+        auto &keys = config["keys"];
         if(keys.isArray() || keys.isList()) {
             int key_count = keys.getLength();
             for(int i = 0; i < key_count; i++) {

--- a/src/logid/actions/KeypressAction.cpp
+++ b/src/logid/actions/KeypressAction.cpp
@@ -37,10 +37,10 @@ void KeypressAction::press()
 
 void KeypressAction::halfRelease()
 {
-    bool skippedFirst = false;
+    bool skipFirst = _config.keys().size() > 1;
     for(auto& key : _config.keys()) {
-        if (!skippedFirst) {
-            skippedFirst = true;
+        if (skipFirst) {
+            skipFirst = false;
             continue;
         }
         virtual_input->releaseKey(key);

--- a/src/logid/actions/KeypressAction.h
+++ b/src/logid/actions/KeypressAction.h
@@ -30,7 +30,7 @@ namespace actions {
         KeypressAction(Device* dev, libconfig::Setting& config);
 
         virtual void press();
-        virtual void secondaryRelease();
+        virtual void halfRelease();
         virtual void release();
 
         virtual uint8_t reprogFlags() const;

--- a/src/logid/actions/KeypressAction.h
+++ b/src/logid/actions/KeypressAction.h
@@ -30,6 +30,7 @@ namespace actions {
         KeypressAction(Device* dev, libconfig::Setting& config);
 
         virtual void press();
+        virtual void secondaryRelease();
         virtual void release();
 
         virtual uint8_t reprogFlags() const;

--- a/src/logid/actions/gesture/AxisGesture.cpp
+++ b/src/logid/actions/gesture/AxisGesture.cpp
@@ -101,7 +101,7 @@ AxisGesture::Config::Config(Device *device, libconfig::Setting &setting) :
     Gesture::Config(device, setting, false)
 {
     try {
-        auto& axis = setting.lookup("axis");
+        auto& axis = setting["axis"];
         if(axis.isNumber()) {
             _axis = axis;
         } else if(axis.getType() == libconfig::Setting::TypeString) {
@@ -123,7 +123,7 @@ AxisGesture::Config::Config(Device *device, libconfig::Setting &setting) :
     }
 
     try {
-        auto& multiplier = setting.lookup("axis_multiplier");
+        auto& multiplier = setting["axis_multiplier"];
         if(multiplier.isNumber()) {
             if(multiplier.getType() == libconfig::Setting::TypeFloat)
                 _multiplier = multiplier;

--- a/src/logid/actions/gesture/Gesture.cpp
+++ b/src/logid/actions/gesture/Gesture.cpp
@@ -38,7 +38,7 @@ Gesture::Config::Config(Device* device, libconfig::Setting& root,
     if(action_required) {
         try {
             _action = Action::makeAction(_device,
-                                         root.lookup("action"));
+                                         root["action"]);
         } catch (libconfig::SettingNotFoundException &e) {
             throw InvalidGesture("action is missing");
         }
@@ -49,7 +49,7 @@ Gesture::Config::Config(Device* device, libconfig::Setting& root,
 
     _threshold = LOGID_GESTURE_DEFAULT_THRESHOLD;
     try {
-        auto& threshold = root.lookup("threshold");
+        auto& threshold = root["threshold"];
         if(threshold.getType() == libconfig::Setting::TypeInt) {
             _threshold = (int)threshold;
             if(_threshold <= 0) {
@@ -76,7 +76,7 @@ std::shared_ptr<Gesture> Gesture::makeGesture(Device *device,
     }
 
     try {
-        auto& gesture_mode = setting.lookup("mode");
+        auto& gesture_mode = setting["mode"];
 
         if(gesture_mode.getType() != libconfig::Setting::TypeString) {
             logPrintf(WARN, "Line %d: Gesture mode must be a string,"

--- a/src/logid/actions/gesture/IntervalGesture.cpp
+++ b/src/logid/actions/gesture/IntervalGesture.cpp
@@ -35,6 +35,7 @@ void IntervalGesture::release(bool primary)
 {
     // Do nothing
     (void)primary; // Suppress unused warning
+    _config.action()->release();
 }
 
 void IntervalGesture::move(int16_t axis)
@@ -47,7 +48,7 @@ void IntervalGesture::move(int16_t axis)
             _config.interval();
     if(new_interval_count > _interval_pass_count) {
         _config.action()->press();
-        _config.action()->release();
+        _config.action()->secondaryRelease();
     }
     _interval_pass_count = new_interval_count;
 }

--- a/src/logid/actions/gesture/IntervalGesture.cpp
+++ b/src/logid/actions/gesture/IntervalGesture.cpp
@@ -48,7 +48,7 @@ void IntervalGesture::move(int16_t axis)
             _config.interval() + 1;
     if(new_interval_count > _interval_pass_count) {
         _config.action()->press();
-        _config.action()->secondaryRelease();
+        _config.action()->halfRelease();
     }
     _interval_pass_count = new_interval_count;
 }

--- a/src/logid/actions/gesture/IntervalGesture.cpp
+++ b/src/logid/actions/gesture/IntervalGesture.cpp
@@ -45,7 +45,7 @@ void IntervalGesture::move(int16_t axis)
         return;
 
     int16_t new_interval_count = (_axis - _config.threshold())/
-            _config.interval();
+            _config.interval() + 1;
     if(new_interval_count > _interval_pass_count) {
         _config.action()->press();
         _config.action()->secondaryRelease();

--- a/src/logid/actions/gesture/IntervalGesture.cpp
+++ b/src/logid/actions/gesture/IntervalGesture.cpp
@@ -66,7 +66,7 @@ IntervalGesture::Config::Config(Device *device, libconfig::Setting &setting) :
     Gesture::Config(device, setting)
 {
     try {
-        auto& interval = setting.lookup("interval");
+        auto& interval = setting["interval"];
         if(interval.getType() != libconfig::Setting::TypeInt) {
             logPrintf(WARN, "Line %d: interval must be an integer, skipping.",
                     interval.getSourceLine());
@@ -76,7 +76,7 @@ IntervalGesture::Config::Config(Device *device, libconfig::Setting &setting) :
     } catch(libconfig::SettingNotFoundException& e) {
         try {
             // pixels is an alias for interval
-            auto& interval = setting.lookup("pixels");
+            auto& interval = setting["pixels"];
             if(interval.getType() != libconfig::Setting::TypeInt) {
                 logPrintf(WARN, "Line %d: pixels must be an integer, skipping.",
                           interval.getSourceLine());

--- a/src/logid/features/HiresScroll.cpp
+++ b/src/logid/features/HiresScroll.cpp
@@ -157,7 +157,7 @@ HiresScroll::Config::Config(Device *dev) : DeviceFeature::Config(dev)
         _mode = 0;
         _mask = 0;
         try {
-            auto& hires = config_root.lookup("hires");
+            auto& hires = config_root["hires"];
             if(hires.getType() == libconfig::Setting::TypeBoolean) {
                 _mask |= hidpp20::HiresScroll::Mode::HiRes;
                 if(hires)
@@ -169,7 +169,7 @@ HiresScroll::Config::Config(Device *dev) : DeviceFeature::Config(dev)
         } catch(libconfig::SettingNotFoundException& e) { }
 
         try {
-            auto& invert = config_root.lookup("invert");
+            auto& invert = config_root["invert"];
             if(invert.getType() == libconfig::Setting::TypeBoolean) {
                 _mask |= hidpp20::HiresScroll::Mode::Inverted;
                 if(invert)
@@ -181,7 +181,7 @@ HiresScroll::Config::Config(Device *dev) : DeviceFeature::Config(dev)
         } catch(libconfig::SettingNotFoundException& e) { }
 
         try {
-            auto& target = config_root.lookup("target");
+            auto& target = config_root["target"];
             if(target.getType() == libconfig::Setting::TypeBoolean) {
                 _mask |= hidpp20::HiresScroll::Mode::Target;
                 if(target)
@@ -194,7 +194,7 @@ HiresScroll::Config::Config(Device *dev) : DeviceFeature::Config(dev)
 
         if(_mode & hidpp20::HiresScroll::Mode::Target) {
             try {
-                auto& up = config_root.lookup("up");
+                auto& up = config_root["up"];
                 try {
                     auto g = actions::Gesture::makeGesture(dev, up);
                     if(g->wheelCompatibility()) {
@@ -214,7 +214,7 @@ HiresScroll::Config::Config(Device *dev) : DeviceFeature::Config(dev)
             }
 
             try {
-                auto& down = config_root.lookup("down");
+                auto& down = config_root["down"];
                 try {
                     auto g = actions::Gesture::makeGesture(dev, down);
                     if(g->wheelCompatibility()) {

--- a/src/logid/features/RemapButton.cpp
+++ b/src/logid/features/RemapButton.cpp
@@ -178,7 +178,7 @@ void RemapButton::Config::_parseButton(libconfig::Setting &setting)
 
     uint16_t cid;
     try {
-        auto& cid_setting = setting.lookup("cid");
+        auto& cid_setting = setting["cid"];
         if(!cid_setting.isNumber()) {
             logPrintf(WARN, "Line %d: cid must be a number, ignoring.",
                     cid_setting.getSourceLine());
@@ -193,7 +193,7 @@ void RemapButton::Config::_parseButton(libconfig::Setting &setting)
 
     try {
         _buttons.emplace(cid, Action::makeAction(_device,
-                setting.lookup("action")));
+                setting["action"]));
     } catch(libconfig::SettingNotFoundException& e) {
         logPrintf(WARN, "Line %d: action is required, ignoring.",
                   setting.getSourceLine());

--- a/src/logid/features/ThumbWheel.cpp
+++ b/src/logid/features/ThumbWheel.cpp
@@ -184,7 +184,7 @@ ThumbWheel::Config::Config(Device* dev) : DeviceFeature::Config(dev)
         }
 
         try {
-            auto& divert = config_root.lookup("divert");
+            auto& divert = config_root["divert"];
             if(divert.getType() == libconfig::Setting::TypeBoolean) {
                 _divert = divert;
             } else {
@@ -194,7 +194,7 @@ ThumbWheel::Config::Config(Device* dev) : DeviceFeature::Config(dev)
         } catch(libconfig::SettingNotFoundException& e) { }
 
         try {
-            auto& invert = config_root.lookup("invert");
+            auto& invert = config_root["invert"];
             if(invert.getType() == libconfig::Setting::TypeBoolean) {
                 _invert = invert;
             } else {
@@ -227,7 +227,7 @@ std::shared_ptr<actions::Action> ThumbWheel::Config::_genAction(Device* dev,
         libconfig::Setting& config_root, const std::string& name)
 {
     try {
-        auto& a_group = config_root.lookup(name);
+        auto& a_group = config_root[name.c_str()];
         try {
             return actions::Action::makeAction(dev, a_group);
         } catch(actions::InvalidAction& e) {
@@ -244,7 +244,7 @@ std::shared_ptr<actions::Gesture> ThumbWheel::Config::_genGesture(Device* dev,
         libconfig::Setting& config_root, const std::string& name)
 {
     try {
-        auto& g_group = config_root.lookup(name);
+        auto& g_group = config_root[name.c_str()];
         try {
             auto g = actions::Gesture::makeGesture(dev, g_group);
             if(g->wheelCompatibility()) {


### PR DESCRIPTION
Note: Also contains a fixed version of #157. Should probably reach a resolution on that before this one. Marked as draft until then.

This pull request allows for one to switch multiple applications in one go by setting Alt+Tab OnInterval in one direction, and Alt+Shift+Tab OnInterval in the other direction.
Fixes #35. It also addresses some related issues that I encountered (fixes #118 and fixes #128).

These changes will break any use case that requires being able to do gestures on multiple axes during one gesture button press. I can't think of any use cases that need that functionality, though.

Changes:
- GestureAction: Restrict movements to a single axis after threshold is reached (issue #35, useful for preventing unintended gesture activations)
- GestureAction: Don't wait till origin before switching directions (issue #128, useful when both directions affect the same state like changing volume or switching workspaces)
- IntervalGesture: Fire action as soon as threshold is reached, instead of waiting for another interval (issue #128)
- Added halfRelease method from IntervalGesture to Action to KeypressAction (issue #118, useful when the OnInterval actions for an axis require holding a key down, like Alt+Tab and Alt+Shift+Tab)