### PR TITLE
Filled in config name for MX Vertical

### DIFF
--- a/TESTED.md
+++ b/TESTED.md
@@ -9,7 +9,7 @@ This is not by any means an exhaustive list. Many more devices are supported but
 |   MX Master    |     Yes     |       `Wireless Mouse MX Master`       |
 | MX Anywhere S2 |     Yes     | `Wireless Mobile Mouse MX Anywhere 2S` |
 | MX Anywhere 3  |     Yes     |            `MX Anywhere 3`             |
-|  MX Vertical   |     Yes     |                                        |
+|  MX Vertical   |     Yes     | `MX Vertical Advanced Ergonomic Mouse` |
 |    MX Ergo     |     Yes     |                                        |
 |      M720      |     Yes     |  `M720 Triathlon Multi-Device Mouse`   |
 |      M590      |     Yes     |     `M585/M590 Multi-Device Mouse`     |


### PR DESCRIPTION
I have such mouse. Filled in missing field in a supported devices table.