### PR TITLE
Fix virtual keyboard

### DIFF
--- a/src/logid/InputDevice.cpp
+++ b/src/logid/InputDevice.cpp
@@ -54,8 +54,10 @@ InputDevice::InputDevice(const char* name)
     int err = libevdev_uinput_create_from_device(device,
             LIBEVDEV_UINPUT_OPEN_MANAGED, &ui_device);
 
-    if(err != 0)
+    if(err != 0) {
+        libevdev_free(device);
         throw std::system_error(-err, std::generic_category());
+    }
 }
 
 InputDevice::~InputDevice()

--- a/src/logid/InputDevice.cpp
+++ b/src/logid/InputDevice.cpp
@@ -45,7 +45,9 @@ InputDevice::InputDevice(const char* name)
 
     ///TODO: Is it really a good idea to enable all events?
     libevdev_enable_event_type(device, EV_KEY);
-    for(unsigned int i = 0; i < KEY_CNT; i++)
+    // KEY_ROTATE_LOCK_TOGGLE is the highest key mapped by
+    // /usr/share/X11/xkb/keycodes/evdev
+    for(unsigned int i = 0; i <= KEY_ROTATE_LOCK_TOGGLE; i++)
         libevdev_enable_event_code(device, EV_KEY, i, nullptr);
     libevdev_enable_event_type(device, EV_REL);
     for(unsigned int i = 0; i < REL_CNT; i++)

--- a/src/logid/InputDevice.h
+++ b/src/logid/InputDevice.h
@@ -20,6 +20,7 @@
 #define LOGID_INPUTDEVICE_H
 
 #include <memory>
+#include <string>
 
 extern "C"
 {


### PR DESCRIPTION
Fixes #166

Starting with systemd 247 (?), desktop environments fail to recognize the virtual input device if it has too many enabled libinput events.

It seems like `KEY_ROTATE_LOCK_TOGGLE` as the highest enabled event is a good limit. This is the highest evdev event mapped by xkb, so the usefulness higher events is limited, anyways.

Kudos to @aragon999 for helping debuggin the issue, especially for the MWE in https://github.com/PixlOne/logiops/issues/166#issuecomment-744592017!

Looks like I was mistaken in https://github.com/PixlOne/logiops/issues/166#issuecomment-744595620 and the limit for the number of events is actually a bit higher, though.

This probably needs testing whether it's a sufficient workaround. A nicer approach would be to extract from the configuration all the event we might need to send, and then only enable those.