### PR TITLE
Register keys for keypress only when needed

### DIFF
--- a/src/logid/InputDevice.cpp
+++ b/src/logid/InputDevice.cpp
@@ -54,8 +54,10 @@ InputDevice::InputDevice(const char* name)
     int err = libevdev_uinput_create_from_device(device,
             LIBEVDEV_UINPUT_OPEN_MANAGED, &ui_device);
 
-    if(err != 0)
+    if(err != 0) {
+        libevdev_free(device);
         throw std::system_error(-err, std::generic_category());
+    }
 }
 
 InputDevice::~InputDevice()

--- a/src/logid/InputDevice.cpp
+++ b/src/logid/InputDevice.cpp
@@ -45,7 +45,9 @@ InputDevice::InputDevice(const char* name)
 
     ///TODO: Is it really a good idea to enable all events?
     libevdev_enable_event_type(device, EV_KEY);
-    for(unsigned int i = 0; i < KEY_CNT; i++)
+    // KEY_ROTATE_LOCK_TOGGLE is the highest key mapped by
+    // /usr/share/X11/xkb/keycodes/evdev
+    for(unsigned int i = 0; i <= KEY_ROTATE_LOCK_TOGGLE; i++)
         libevdev_enable_event_code(device, EV_KEY, i, nullptr);
     libevdev_enable_event_type(device, EV_REL);
     for(unsigned int i = 0; i < REL_CNT; i++)

--- a/src/logid/InputDevice.cpp
+++ b/src/logid/InputDevice.cpp
@@ -43,12 +43,7 @@ InputDevice::InputDevice(const char* name)
     device = libevdev_new();
     libevdev_set_name(device, name);
 
-    ///TODO: Is it really a good idea to enable all events?
     libevdev_enable_event_type(device, EV_KEY);
-    // KEY_ROTATE_LOCK_TOGGLE is the highest key mapped by
-    // /usr/share/X11/xkb/keycodes/evdev
-    for(unsigned int i = 0; i <= KEY_ROTATE_LOCK_TOGGLE; i++)
-        libevdev_enable_event_code(device, EV_KEY, i, nullptr);
     libevdev_enable_event_type(device, EV_REL);
     for(unsigned int i = 0; i < REL_CNT; i++)
         libevdev_enable_event_code(device, EV_REL, i, nullptr);
@@ -66,6 +61,18 @@ InputDevice::~InputDevice()
 {
     libevdev_uinput_destroy(ui_device);
     libevdev_free(device);
+}
+
+void InputDevice::registerKey(uint code)
+{
+    libevdev_enable_event_code(device, EV_KEY, code, nullptr);
+    int err = libevdev_uinput_create_from_device(device,
+            LIBEVDEV_UINPUT_OPEN_MANAGED, &ui_device);
+
+    if(err != 0) {
+        libevdev_free(device);
+        throw std::system_error(-err, std::generic_category());
+    }
 }
 
 void InputDevice::moveAxis(uint axis, int movement)

--- a/src/logid/InputDevice.cpp
+++ b/src/logid/InputDevice.cpp
@@ -89,6 +89,8 @@ void InputDevice::registerKey(uint code)
 
     if(err != 0) {
         libevdev_free(device);
+        device = nullptr;
+        ui_device = nullptr;
         throw std::system_error(-err, std::generic_category());
     }
 

--- a/src/logid/InputDevice.cpp
+++ b/src/logid/InputDevice.cpp
@@ -44,6 +44,18 @@ InputDevice::InputDevice(const char* name)
     libevdev_set_name(device, name);
 
     libevdev_enable_event_type(device, EV_KEY);
+    for (unsigned int i = 0; i < KEY_CNT; i++) {
+        // Enable some keys which a normal keyboard should have
+        // by default, i.e. a-z, modifier keys and so on, see:
+        // /usr/include/linux/input-event-codes.h
+        if (i < 128) {
+            registered_keys[i] = true;
+            libevdev_enable_event_code(device, EV_KEY, i, nullptr);
+        } else {
+            registered_keys[i] = false;
+        }
+    }
+
     libevdev_enable_event_type(device, EV_REL);
     for(unsigned int i = 0; i < REL_CNT; i++)
         libevdev_enable_event_code(device, EV_REL, i, nullptr);
@@ -65,6 +77,12 @@ InputDevice::~InputDevice()
 
 void InputDevice::registerKey(uint code)
 {
+    if (registered_keys[code]) {
+        return;
+    }
+
+    libevdev_uinput_destroy(ui_device);
+
     libevdev_enable_event_code(device, EV_KEY, code, nullptr);
     int err = libevdev_uinput_create_from_device(device,
             LIBEVDEV_UINPUT_OPEN_MANAGED, &ui_device);
@@ -73,6 +91,8 @@ void InputDevice::registerKey(uint code)
         libevdev_free(device);
         throw std::system_error(-err, std::generic_category());
     }
+
+    registered_keys[code] = true;
 }
 
 void InputDevice::moveAxis(uint axis, int movement)

--- a/src/logid/InputDevice.h
+++ b/src/logid/InputDevice.h
@@ -44,6 +44,7 @@ namespace logid
         explicit InputDevice(const char *name);
         ~InputDevice();
 
+        void registerKey(uint code);
         void moveAxis(uint axis, int movement);
         void pressKey(uint code);
         void releaseKey(uint code);

--- a/src/logid/InputDevice.h
+++ b/src/logid/InputDevice.h
@@ -58,6 +58,7 @@ namespace logid
 
         static uint _toEventCode(uint type, const std::string& name);
 
+        bool registered_keys[KEY_CNT];
         libevdev* device;
         libevdev_uinput* ui_device{};
     };

--- a/src/logid/InputDevice.h
+++ b/src/logid/InputDevice.h
@@ -20,6 +20,7 @@
 #define LOGID_INPUTDEVICE_H
 
 #include <memory>
+#include <string>
 
 extern "C"
 {

--- a/src/logid/actions/KeypressAction.cpp
+++ b/src/logid/actions/KeypressAction.cpp
@@ -64,9 +64,11 @@ KeypressAction::Config::Config(Device* device, libconfig::Setting& config) :
                 auto& key = keys[i];
                 if(key.isNumber()) {
                     _keys.push_back(key);
+                    virtual_input->registerKey(key);
                 } else if(key.getType() == libconfig::Setting::TypeString) {
                     try {
                         _keys.push_back(virtual_input->toKeyCode(key));
+                        virtual_input->registerKey(virtual_input->toKeyCode(key));
                     } catch(InputDevice::InvalidEventCode& e) {
                         logPrintf(WARN, "Line %d: Invalid keycode %s, skipping."
                             , key.getSourceLine(), key.c_str());


### PR DESCRIPTION
there seems to be an issue that with too many registered events some window
manager cannot recognize the device as input device with systemd 247.

I created this code in addition to the pull request of @kris7t https://github.com/PixlOne/logiops/pull/182.
Also thanks for the help in debugging and finding the solution to the problem.

I am not sure if it is good to call `libevdev_uinput_create_from_device` every time a key was added, or to change the logic somehow.

I am open to any suggestions.

Thank you for creating this software :-)

Edit: Rebased the PR onto the PR #182.