### PR TITLE
Enable axis in virtual_input device only when needed

### DIFF
--- a/src/logid/InputDevice.h
+++ b/src/logid/InputDevice.h
@@ -45,6 +45,7 @@ namespace logid
         ~InputDevice();
 
         void registerKey(uint code);
+        void registerAxis(uint axis);
         void moveAxis(uint axis, int movement);
         void pressKey(uint code);
         void releaseKey(uint code);
@@ -55,10 +56,12 @@ namespace logid
 
     private:
         void _sendEvent(uint type, uint code, int value);
+        void _enableEvent(uint type, uint name);
 
         static uint _toEventCode(uint type, const std::string& name);
 
         bool registered_keys[KEY_CNT];
+        bool registered_axis[REL_CNT];
         libevdev* device;
         libevdev_uinput* ui_device{};
     };

--- a/src/logid/actions/gesture/AxisGesture.cpp
+++ b/src/logid/actions/gesture/AxisGesture.cpp
@@ -104,9 +104,11 @@ AxisGesture::Config::Config(Device *device, libconfig::Setting &setting) :
         auto& axis = setting.lookup("axis");
         if(axis.isNumber()) {
             _axis = axis;
+            virtual_input->registerAxis(_axis);
         } else if(axis.getType() == libconfig::Setting::TypeString) {
             try {
                 _axis = virtual_input->toAxisCode(axis);
+                virtual_input->registerAxis(_axis);
             } catch(InputDevice::InvalidEventCode& e) {
                 logPrintf(WARN, "Line %d: Invalid axis %s, skipping."
                         , axis.getSourceLine(), axis.c_str());
@@ -138,8 +140,11 @@ AxisGesture::Config::Config(Device *device, libconfig::Setting &setting) :
         // Ignore
     }
 
-    if(InputDevice::getLowResAxis(_axis) != -1)
+    int low_res_axis = InputDevice::getLowResAxis(_axis);
+    if(low_res_axis != -1) {
         _multiplier *= 120;
+        virtual_input->registerAxis(low_res_axis);
+    }
 }
 
 unsigned int AxisGesture::Config::axis() const


### PR DESCRIPTION
From [that comment](https://github.com/PixlOne/logiops/pull/183#issuecomment-748700368) I thought I add this feature as well :-)

At the first implementation I did not saw that actually this should be done as well.

Unfortunately I do not see a way without recreating the device after the events are changed. If you know of a solution I would be happy to implement this.