### PR TITLE
Update Device.cpp

### DIFF
--- a/src/logid/Device.cpp
+++ b/src/logid/Device.cpp
@@ -16,6 +16,7 @@
  *
  */
 
+#include <thread>
 #include "util/log.h"
 #include "features/DPI.h"
 #include "Device.h"


### PR DESCRIPTION
Build failed for fedora 34 (rawhide), with the error
`error: 'sleep_for' is not a member of 'std::this_thread' std::this_thread::sleep_for(std::chrono::milliseconds(100));`
It seems that 
`#include <thread>`
need to be added.
Please see issue #199 