### PR TITLE
Add Gentoo Linux to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ This project requires a C++14 compiler, `cmake`, `libevdev`, `libudev`, and `lib
 
 **Arch Linux:** `sudo pacman -S cmake libevdev libconfig pkgconf`
 
+**Gentoo Linux** `sudo emerge dev-libs/libconfig dev-libs/libevdev dev-util/cmake virtual/libudev`
+
 **Solus:** `sudo eopkg install libevdev-devel libconfig-devel libgudev-devel`
 
 **Fedora:** `sudo dnf install cmake libevdev-devel systemd-devel libconfig-devel gcc-c++`

--- a/README.md
+++ b/README.md
@@ -15,15 +15,15 @@ Default location for the configuration file is /etc/logid.cfg, but another can b
 
 This project requires a C++14 compiler, `cmake`, `libevdev`, `libudev`, and `libconfig`. For popular distributions, I've included commands below.
 
+**Arch Linux:** `sudo pacman -S cmake libevdev libconfig pkgconf`
+
 **Debian/Ubuntu:** `sudo apt install cmake libevdev-dev libudev-dev libconfig++-dev`
 
-**Arch Linux:** `sudo pacman -S cmake libevdev libconfig pkgconf`
+**Fedora:** `sudo dnf install cmake libevdev-devel systemd-devel libconfig-devel gcc-c++`
 
 **Gentoo Linux** `sudo emerge dev-libs/libconfig dev-libs/libevdev dev-util/cmake virtual/libudev`
 
 **Solus:** `sudo eopkg install libevdev-devel libconfig-devel libgudev-devel`
-
-**Fedora:** `sudo dnf install cmake libevdev-devel systemd-devel libconfig-devel gcc-c++`
 
 ## Building
 


### PR DESCRIPTION
Add Gentoo Linux to README.md

Note: Gentoo has this package in it's main repo, so a normal user can also just do `emerge logiops`.