### PR TITLE
Add Installation section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@ This is an unofficial driver for Logitech mice and keyboard.
 
 This is currently only compatible with HID++ \>2.0 devices.
 
+## Installation
+
+Logiops is currently available in packaged form for the following distributions:
+
+**Debian (Sid only)** `sudo apt install logiops`
+
+**Arch Linux:**: `sudo pacman -S logiops-git`
+
+**Fedora (>=32)**: `sudo dnf install logiops`
+
+All packages install logiops with the logid service in a disabled state so be sure to enable it with `sudo systemctl enable --now logid` after you have configured it.
+
 ## Configuration
 [Refer to the wiki for details.](https://github.com/PixlOne/logiops/wiki/Configuration)
 
@@ -11,7 +23,7 @@ You may also refer to [logid.example.cfg](./logid.example.cfg) for an example.
 
 Default location for the configuration file is /etc/logid.cfg, but another can be specified using the `-c` flag.
 
-## Dependencies
+## Build Dependencies
 
 This project requires a C++14 compiler, `cmake`, `libevdev`, `libudev`, and `libconfig`. For popular distributions, I've included commands below.
 
@@ -34,7 +46,13 @@ cmake ..
 make
 ```
 
-To install, run `sudo make install` after building. You can set the daemon to start at boot by running `sudo systemctl enable logid` or `sudo systemctl enable --now logid` if you want to enable and start the daemon.
+To install, run the following after building:
+```bash
+sudo make install
+sudo systemctl daemon-reload
+```
+
+You can set the daemon to start at boot by running `sudo systemctl enable logid` or `sudo systemctl enable --now logid` if you want to enable and start the daemon.
 
 ## Donate
 This program is (and will always be) provided free of charge. If you would like to support the development of this project by donating, you can donate to my Ko-Fi below.


### PR DESCRIPTION
If a distribution package is available then that should be preferred over building manually. 

This change is inspired by a few recent issues which were seemingly caused by missed steps during building. 