### PR TITLE
Fix index underflow causing segfault on DPI change

### DIFF
--- a/src/logid/features/DPI.cpp
+++ b/src/logid/features/DPI.cpp
@@ -103,7 +103,9 @@ void DPI::setDPI(uint16_t dpi, uint8_t sensor)
     hidpp20::AdjustableDPI::SensorDPIList dpi_list;
     if(_dpi_lists.size() <= sensor) {
         dpi_list = _adjustable_dpi->getSensorDPIList(sensor);
-        for(std::size_t i = _dpi_lists.size()-1; i <= sensor; i++) {
+        std::ptrdiff_t start = _dpi_lists.size()-1;
+        if(start < 0) start = 0;
+        for(std::size_t i = start; i <= sensor; i++) {
             _dpi_lists.push_back(_adjustable_dpi->getSensorDPIList(i));
         }
     }

--- a/src/logid/features/DPI.cpp
+++ b/src/logid/features/DPI.cpp
@@ -103,11 +103,10 @@ void DPI::setDPI(uint16_t dpi, uint8_t sensor)
     hidpp20::AdjustableDPI::SensorDPIList dpi_list;
     if(_dpi_lists.size() <= sensor) {
         dpi_list = _adjustable_dpi->getSensorDPIList(sensor);
-        std::ptrdiff_t start = _dpi_lists.size()-1;
-        if(start < 0) start = 0;
-        for(std::size_t i = start; i <= sensor; i++) {
+        for(std::size_t i = _dpi_lists.size(); i < sensor; i++) {
             _dpi_lists.push_back(_adjustable_dpi->getSensorDPIList(i));
         }
+        _dpi_lists.push_back(dpi_list);
     }
     dpi_list = _dpi_lists[sensor];
     _adjustable_dpi->setSensorDPI(sensor, getClosestDPI(dpi_list, dpi));


### PR DESCRIPTION
Fixes #146 

Summary: since `size_t i` is unsigned, when it is set to `_dpi_lists.size() - 1` and `_dpi_lists.size() == 0`, `i` underflows and the loop to get the sensor DPI list never runs. This fixes that by using an intermediate `ptrdiff_t` variable, which has the same range as `size_t` but is signed.

Fix tested on my MX Vertical, allows me to cycle DPI correctly now. Let me know if any changes are necessary, happy to make them!