### PR TITLE
InputDevice: Do not register REL_DIAL axis (fixes REL_HWHEEL injection)

### DIFF
--- a/src/logid/InputDevice.cpp
+++ b/src/logid/InputDevice.cpp
@@ -58,7 +58,10 @@ InputDevice::InputDevice(const char* name)
 
     libevdev_enable_event_type(device, EV_REL);
     for(unsigned int i = 0; i < REL_CNT; i++)
-        libevdev_enable_event_code(device, EV_REL, i, nullptr);
+        if (i != REL_DIAL)
+            // REL_DIAL conflicts with REL_HWHEEL or REL_HWHEEL_HI_RES:
+            // Horizontal scroll events not handled by OS if device has REL_DIAL
+            libevdev_enable_event_code(device, EV_REL, i, nullptr);
 
     int err = libevdev_uinput_create_from_device(device,
             LIBEVDEV_UINPUT_OPEN_MANAGED, &ui_device);


### PR DESCRIPTION
On my system (Kubuntu 20.04 AMD64 with Linux 5.4.0-54-generic #60-Ubuntu SMP)
REL_HWHEEL events do not work if logid have registered REL_DIAL axis
(events got injected and can be seen in evtest, but not handled by apps).

Fixes https://github.com/PixlOne/logiops/issues/244
Fixes https://github.com/PixlOne/logiops/issues/281