### PR TITLE
run service After bluetooth.target

### DIFF
--- a/src/logid/logid.service.cmake
+++ b/src/logid/logid.service.cmake
@@ -1,7 +1,7 @@
 [Unit]
 Description=Logitech Configuration Daemon
 StartLimitIntervalSec=0
-After=multi-user.target
+After=multi-user.target bluetooth.target
 Wants=multi-user.target
 
 [Service]


### PR DESCRIPTION
When systemd starts logid.service without taking bluetooth.target into
account, you see the following error for some device N:

    [WARN] Error adding device /dev/hidrawN: std::exception

Restarting the service with `systemctl restart logid` fixes it. This
also happens on wake from suspend.

This commit adds After=bluetooth.target to the service unit definition
which fixes the problem.

This issue has come up in #265, #156, and #148. I don't know if this will fix everyone's issues, however, so some testing would be much appreciated.