### PR TITLE
Added MX Ergo Config Name

### DIFF
--- a/TESTED.md
+++ b/TESTED.md
@@ -10,7 +10,7 @@ This is not by any means an exhaustive list. Many more devices are supported but
 | MX Anywhere S2 |     Yes     | `Wireless Mobile Mouse MX Anywhere 2S` |
 | MX Anywhere 3  |     Yes     |            `MX Anywhere 3`             |
 |  MX Vertical   |     Yes     | `MX Vertical Advanced Ergonomic Mouse` |
-|    MX Ergo     |     Yes     |                                        |
+|    MX Ergo     |     Yes     |   `MX Ergo Multi-Device Trackball `    |
 |      M720      |     Yes     |  `M720 Triathlon Multi-Device Mouse`   |
 |      M590      |     Yes     |     `M585/M590 Multi-Device Mouse`     |
 |      T400      |     Yes     |        `Zone Touch Mouse T400`         |


### PR DESCRIPTION
The space at the end was not placed by mistake. It is necessary to have its config recognized. As per https://github.com/PixlOne/logiops/issues/65#issuecomment-723559895
Config example here: https://github.com/TobiasDev/dot-files/blob/master/logiops/logid.cfg