### PR TITLE
Allow user to specify systemd install dir

### DIFF
--- a/src/logid/CMakeLists.txt
+++ b/src/logid/CMakeLists.txt
@@ -89,10 +89,12 @@ target_link_libraries(logid ${CMAKE_THREAD_LIBS_INIT} ${EVDEV_LIBRARY} config++
 
 install(TARGETS logid DESTINATION bin)
 
-if (SYSTEMD_FOUND AND "${SYSTEMD_SERVICES_INSTALL_DIR}" STREQUAL "")
-    execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE}
-        --variable=systemdsystemunitdir systemd
-        OUTPUT_VARIABLE SYSTEMD_SERVICES_INSTALL_DIR)
+if (SYSTEMD_FOUND)
+    if ("${SYSTEMD_SERVICES_INSTALL_DIR}" STREQUAL "")
+         execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE}
+             --variable=systemdsystemunitdir systemd
+             OUTPUT_VARIABLE SYSTEMD_SERVICES_INSTALL_DIR)
+    endif()
     string(REGEX REPLACE "[ \t\n]+" "" SYSTEMD_SERVICES_INSTALL_DIR
            "${SYSTEMD_SERVICES_INSTALL_DIR}")
     configure_file(logid.service.cmake ${CMAKE_BINARY_DIR}/logid.service)


### PR DESCRIPTION
In NixOS, and probably other package repositories, the `systemdsystemunitdir` is read only. So attempting to install it will always fail.