### PR TITLE
Fix logiops not working on boot

### DIFF
--- a/src/logid/logid.service.cmake
+++ b/src/logid/logid.service.cmake
@@ -6,6 +6,7 @@ Wants=multi-user.target
 
 [Service]
 Type=simple
+ExecStartPre=/usr/sbin/modprobe hid_logitech_hidpp || :
 ExecStart=${CMAKE_INSTALL_PREFIX}/bin/logid
 User=root
 ExecReload=/bin/kill -HUP $MAINPID


### PR DESCRIPTION
Sometimes, if the mouse has not yet been moved (aka detected by the system) before the service tries to start, it only fails and a manual restart of the service is needed to successfully start the service and have it pick up the device.

This fixes: #280 #269 #265 (and probably some others too)