### PR TITLE
Added MX Master 3 Mac to TESTED.md

### DIFF
--- a/TESTED.md
+++ b/TESTED.md
@@ -2,17 +2,18 @@
 
 This is not by any means an exhaustive list. Many more devices are supported but these devices are the ones that are confirmed to be working. To add to this list, submit a pull request adding your device.
 
-|     Device     | Compatible? |              Config Name               |
-| :------------: | :---------: | :------------------------------------: |
-|  MX Master 3   |     Yes     |      `Wireless Mouse MX Master 3`      |
-|  MX Master 2S  |     Yes     |     `Wireless Mouse MX Master 2S`      |
-|   MX Master    |     Yes     |       `Wireless Mouse MX Master`       |
-| MX Anywhere S2 |     Yes     | `Wireless Mobile Mouse MX Anywhere 2S` |
-| MX Anywhere 3  |     Yes     |            `MX Anywhere 3`             |
-|  MX Vertical   |     Yes     | `MX Vertical Advanced Ergonomic Mouse` |
-|    MX Ergo     |     Yes     |   `MX Ergo Multi-Device Trackball `    |
-|      M720      |     Yes     |  `M720 Triathlon Multi-Device Mouse`   |
-|      M590      |     Yes     |     `M585/M590 Multi-Device Mouse`     |
-|      T400      |     Yes     |        `Zone Touch Mouse T400`         |
-|    MX Keys     |     Yes     |      `MX Keys Wireless Keyboard`       |
-|      M500s     |     Yes     |     `Advanced Corded Mouse M500s`      |
+|     Device       | Compatible? |              Config Name               |
+| :------------:   | :---------: | :------------------------------------: |
+|  MX Master 3     |     Yes     |      `Wireless Mouse MX Master 3`      |
+|  MX Master 3 Mac |     Yes     |          `MX Master 3 for Mac`         |
+|  MX Master 2S    |     Yes     |     `Wireless Mouse MX Master 2S`      |
+|   MX Master      |     Yes     |       `Wireless Mouse MX Master`       |
+| MX Anywhere S2   |     Yes     | `Wireless Mobile Mouse MX Anywhere 2S` |
+| MX Anywhere 3    |     Yes     |            `MX Anywhere 3`             |
+|  MX Vertical     |     Yes     | `MX Vertical Advanced Ergonomic Mouse` |
+|    MX Ergo       |     Yes     |   `MX Ergo Multi-Device Trackball `    |
+|      M720        |     Yes     |  `M720 Triathlon Multi-Device Mouse`   |
+|      M590        |     Yes     |     `M585/M590 Multi-Device Mouse`     |
+|      T400        |     Yes     |        `Zone Touch Mouse T400`         |
+|    MX Keys       |     Yes     |      `MX Keys Wireless Keyboard`       |
+|      M500s       |     Yes     |     `Advanced Corded Mouse M500s`      |


### PR DESCRIPTION
I thought `Wireless Mouse MX Master 3` was going to work for the Mac version as well.

Turns out it didn't, you have to specify the config name `MX Master 3 for Mac`.