### PR TITLE
Set 0 buffer for stdout

### DIFF
--- a/src/logid/logid.cpp
+++ b/src/logid/logid.cpp
@@ -135,6 +135,12 @@ int main(int argc, char** argv) {
     std::shared_ptr<Configuration> config;
     std::shared_ptr<InputDevice> virtual_input;
 
+
+    /* Set stdout buff to Null so that loging system like journal
+     * can actually read it.
+     */
+    setbuf(stdout, NULL);
+
     // Read config
     try {
         config = std::make_shared<Configuration>(options.config_file);


### PR DESCRIPTION
Currently, journald cant follow logiops logs because buffer is rarely synced,
even after setting "\n" at each line end.

This pr will set stdout buff to 0, so that logs can always be followed.
