### PR TITLE
Some fixes for non glibc systems

### DIFF
--- a/src/logid/actions/KeypressAction.cpp
+++ b/src/logid/actions/KeypressAction.cpp
@@ -85,7 +85,7 @@ KeypressAction::Config::Config(Device* device, libconfig::Setting& config) :
     }
 }
 
-std::vector<uint>& KeypressAction::Config::keys()
+std::vector<unsigned int>& KeypressAction::Config::keys()
 {
     return _keys;
 }

--- a/src/logid/actions/KeypressAction.h
+++ b/src/logid/actions/KeypressAction.h
@@ -38,9 +38,9 @@ namespace actions {
         {
         public:
             explicit Config(Device* device, libconfig::Setting& root);
-            std::vector<uint>& keys();
+            std::vector<unsigned int>& keys();
         protected:
-            std::vector<uint> _keys;
+            std::vector<unsigned int> _keys;
         };
     protected:
         Config _config;

--- a/src/logid/backend/raw/RawDevice.cpp
+++ b/src/logid/backend/raw/RawDevice.cpp
@@ -39,6 +39,7 @@ extern "C"
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/ioctl.h>
+#include <sys/time.h>
 #include <linux/hidraw.h>
 }
 


### PR DESCRIPTION
- On non glibc systems (sometimes) `uint` is not available hence using `unsigned int` instead.
- For `timeval`, <sys/time.h> is needed to be imported on non glibc systems.

Signed-off-by: listout <listout@protonmail.com>