### PR TITLE
Prevent false positive in secondary axis for gestures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 *.swp
 *~
 /compile_commands.json
+
+# clangd
+/.cache

--- a/src/logid/actions/GestureAction.h
+++ b/src/logid/actions/GestureAction.h
@@ -37,7 +37,6 @@ namespace actions {
             Right
         };
         static Direction toDirection(std::string direction);
-        static Direction toDirection(int16_t x, int16_t y);
 
         GestureAction(Device* dev, libconfig::Setting& config);
 

--- a/src/logid/actions/gesture/AxisGesture.cpp
+++ b/src/logid/actions/gesture/AxisGesture.cpp
@@ -32,12 +32,13 @@ void AxisGesture::press(bool init_threshold)
     _axis = init_threshold ? _config.threshold() : 0;
     _axis_remainder = 0;
     _hires_remainder = 0;
+    _executed = false;
 }
 
 bool AxisGesture::release()
 {
     // Do nothing
-    return _axis >= _config.threshold();
+    return _executed;
 }
 
 void AxisGesture::move(int16_t axis, int16_t secondary_axis)
@@ -86,6 +87,8 @@ void AxisGesture::move(int16_t axis, int16_t secondary_axis)
         } else {
             virtual_input->moveAxis(_config.axis(), move_floor);
         }
+
+        _executed = true;
     }
     _axis = new_axis;
 }

--- a/src/logid/actions/gesture/AxisGesture.cpp
+++ b/src/logid/actions/gesture/AxisGesture.cpp
@@ -34,14 +34,16 @@ void AxisGesture::press(bool init_threshold)
     _hires_remainder = 0;
 }
 
-void AxisGesture::release(bool primary)
+bool AxisGesture::release()
 {
     // Do nothing
-    (void)primary; // Suppress unused warning
+    return _axis >= _config.threshold();
 }
 
-void AxisGesture::move(int16_t axis)
+void AxisGesture::move(int16_t axis, int16_t secondary_axis)
 {
+    (void)secondary_axis; // Suppress unused warning
+
     int16_t new_axis = _axis+axis;
     int low_res_axis = InputDevice::getLowResAxis(_config.axis());
     int hires_remainder = _hires_remainder;
@@ -50,6 +52,7 @@ void AxisGesture::move(int16_t axis)
         double move = axis;
         if(_axis < _config.threshold())
             move = new_axis - _config.threshold();
+
         bool negative_multiplier = _config.multiplier() < 0;
         if(negative_multiplier)
             move *= -_config.multiplier();
@@ -85,11 +88,6 @@ void AxisGesture::move(int16_t axis)
         }
     }
     _axis = new_axis;
-}
-
-bool AxisGesture::metThreshold() const
-{
-    return _axis >= _config.threshold();
 }
 
 void AxisGesture::setHiresMultiplier(double multiplier)

--- a/src/logid/actions/gesture/AxisGesture.h
+++ b/src/logid/actions/gesture/AxisGesture.h
@@ -53,6 +53,7 @@ namespace actions
         int16_t _axis;
         double _axis_remainder;
         int _hires_remainder;
+        bool _executed;
         Config _config;
     };
 }}

--- a/src/logid/actions/gesture/AxisGesture.h
+++ b/src/logid/actions/gesture/AxisGesture.h
@@ -21,41 +21,40 @@
 #include "Gesture.h"
 
 namespace logid {
-    namespace actions
+namespace actions
+{
+    class AxisGesture : public Gesture
     {
-        class AxisGesture : public Gesture
+    public:
+        AxisGesture(Device* device, libconfig::Setting& root);
+
+        virtual void press(bool init_threshold=false);
+        virtual bool release();
+        virtual void move(int16_t primary_axis, int16_t secondary_axis);
+
+        virtual bool wheelCompatibility() const;
+
+        void setHiresMultiplier(double multiplier);
+
+        class Config : public Gesture::Config
         {
         public:
-            AxisGesture(Device* device, libconfig::Setting& root);
-
-            virtual void press(bool init_threshold=false);
-            virtual void release(bool primary=false);
-            virtual void move(int16_t axis);
-
-            virtual bool wheelCompatibility() const;
-            virtual bool metThreshold() const;
-
+            Config(Device* device, libconfig::Setting& setting);
+            unsigned int axis() const;
+            double multiplier() const;
             void setHiresMultiplier(double multiplier);
-
-            class Config : public Gesture::Config
-            {
-            public:
-                Config(Device* device, libconfig::Setting& setting);
-                unsigned int axis() const;
-                double multiplier() const;
-                void setHiresMultiplier(double multiplier);
-            private:
-                unsigned int _axis;
-                double _multiplier = 1;
-                double _hires_multiplier = 1;
-            };
-
-        protected:
-            int16_t _axis;
-            double _axis_remainder;
-            int _hires_remainder;
-            Config _config;
+        private:
+            unsigned int _axis;
+            double _multiplier = 1;
+            double _hires_multiplier = 1;
         };
-    }}
+
+    protected:
+        int16_t _axis;
+        double _axis_remainder;
+        int _hires_remainder;
+        Config _config;
+    };
+}}
 
 #endif //LOGID_ACTION_AXISGESTURE_H

--- a/src/logid/actions/gesture/Gesture.h
+++ b/src/logid/actions/gesture/Gesture.h
@@ -43,11 +43,10 @@ namespace actions
     {
     public:
         virtual void press(bool init_threshold=false) = 0;
-        virtual void release(bool primary=false) = 0;
-        virtual void move(int16_t axis) = 0;
+        virtual bool release() = 0;
+        virtual void move(int16_t axis, int16_t secondary_axis) = 0;
 
         virtual bool wheelCompatibility() const = 0;
-        virtual bool metThreshold() const = 0;
 
         virtual ~Gesture() = default;
 

--- a/src/logid/actions/gesture/IntervalGesture.cpp
+++ b/src/logid/actions/gesture/IntervalGesture.cpp
@@ -51,7 +51,7 @@ void IntervalGesture::move(int16_t axis, int16_t secondary_axis)
     if(_axis < _config.threshold())
         return;
 
-    if(abs(_abs_axis) <= abs(_abs_secondary_axis))
+    if(_abs_axis <= _abs_secondary_axis)
         // If the total movement in secondary_axis is more than primary axis.
         // Don't do anything as this is most likely not intentional
         return;

--- a/src/logid/actions/gesture/IntervalGesture.h
+++ b/src/logid/actions/gesture/IntervalGesture.h
@@ -29,11 +29,10 @@ namespace actions
         IntervalGesture(Device* device, libconfig::Setting& root);
 
         virtual void press(bool init_threshold=false);
-        virtual void release(bool primary=false);
-        virtual void move(int16_t axis);
+        virtual bool release();
+        virtual void move(int16_t axis, int16_t secondary_axis);
 
         virtual bool wheelCompatibility() const;
-        virtual bool metThreshold() const;
 
         class Config : public Gesture::Config
         {
@@ -46,6 +45,8 @@ namespace actions
 
     protected:
         int16_t _axis;
+        int16_t _abs_axis;
+        int16_t _abs_secondary_axis;
         int16_t _interval_pass_count;
         Config _config;
     };

--- a/src/logid/actions/gesture/NullGesture.cpp
+++ b/src/logid/actions/gesture/NullGesture.cpp
@@ -29,23 +29,19 @@ void NullGesture::press(bool init_threshold)
     _axis = init_threshold ? _config.threshold() : 0;
 }
 
-void NullGesture::release(bool primary)
+bool NullGesture::release()
 {
     // Do nothing
-    (void)primary; // Suppress unused warning
+    return _axis > _config.threshold();
 }
 
-void NullGesture::move(int16_t axis)
+void NullGesture::move(int16_t axis, int16_t secondary_axis)
 {
+    (void)secondary_axis; // Suppress unused warning
     _axis += axis;
 }
 
 bool NullGesture::wheelCompatibility() const
 {
     return true;
-}
-
-bool NullGesture::metThreshold() const
-{
-    return _axis > _config.threshold();
 }

--- a/src/logid/actions/gesture/NullGesture.h
+++ b/src/logid/actions/gesture/NullGesture.h
@@ -29,11 +29,10 @@ namespace actions
         NullGesture(Device* device, libconfig::Setting& setting);
 
         virtual void press(bool init_threshold=false);
-        virtual void release(bool primary=false);
-        virtual void move(int16_t axis);
+        virtual bool release();
+        virtual void move(int16_t axis, int16_t secondary_axis);
 
         virtual bool wheelCompatibility() const;
-        virtual bool metThreshold() const;
     protected:
         int16_t _axis;
         Gesture::Config _config;

--- a/src/logid/actions/gesture/ReleaseGesture.cpp
+++ b/src/logid/actions/gesture/ReleaseGesture.cpp
@@ -27,27 +27,27 @@ ReleaseGesture::ReleaseGesture(Device *device, libconfig::Setting &root) :
 void ReleaseGesture::press(bool init_threshold)
 {
     _axis = init_threshold ? _config.threshold() : 0;
+    _secondary_axis = 0;
 }
 
-void ReleaseGesture::release(bool primary)
+bool ReleaseGesture::release()
 {
-    if(metThreshold() && primary) {
+    if(_axis >= _config.threshold() && abs(_axis) > abs(_secondary_axis)) {
         _config.action()->press();
         _config.action()->release();
+        return true;
     }
+    return false;
 }
 
-void ReleaseGesture::move(int16_t axis)
+void ReleaseGesture::move(int16_t axis, int16_t secondary_axis)
 {
+
     _axis += axis;
+    _secondary_axis += secondary_axis;
 }
 
 bool ReleaseGesture::wheelCompatibility() const
 {
     return false;
-}
-
-bool ReleaseGesture::metThreshold() const
-{
-    return _axis >= _config.threshold();
 }

--- a/src/logid/actions/gesture/ReleaseGesture.cpp
+++ b/src/logid/actions/gesture/ReleaseGesture.cpp
@@ -27,12 +27,12 @@ ReleaseGesture::ReleaseGesture(Device *device, libconfig::Setting &root) :
 void ReleaseGesture::press(bool init_threshold)
 {
     _axis = init_threshold ? _config.threshold() : 0;
-    _secondary_axis = 0;
+    _abs_secondary_axis = 0;
 }
 
 bool ReleaseGesture::release()
 {
-    if(_axis >= _config.threshold() && abs(_axis) > abs(_secondary_axis)) {
+    if(_axis >= _config.threshold() && _axis > abs(_abs_secondary_axis)) {
         _config.action()->press();
         _config.action()->release();
         return true;
@@ -44,7 +44,7 @@ void ReleaseGesture::move(int16_t axis, int16_t secondary_axis)
 {
 
     _axis += axis;
-    _secondary_axis += secondary_axis;
+    _abs_secondary_axis += abs(secondary_axis);
 }
 
 bool ReleaseGesture::wheelCompatibility() const

--- a/src/logid/actions/gesture/ReleaseGesture.h
+++ b/src/logid/actions/gesture/ReleaseGesture.h
@@ -29,14 +29,14 @@ namespace actions
         ReleaseGesture(Device* device, libconfig::Setting& root);
 
         virtual void press(bool init_threshold=false);
-        virtual void release(bool primary=false);
-        virtual void move(int16_t axis);
+        virtual bool release();
+        virtual void move(int16_t axis, int16_t secondary_axis);
 
         virtual bool wheelCompatibility() const;
-        virtual bool metThreshold() const;
 
     protected:
         int16_t _axis;
+        int16_t _secondary_axis;
         Gesture::Config _config;
     };
 }}

--- a/src/logid/actions/gesture/ReleaseGesture.h
+++ b/src/logid/actions/gesture/ReleaseGesture.h
@@ -36,7 +36,7 @@ namespace actions
 
     protected:
         int16_t _axis;
-        int16_t _secondary_axis;
+        int16_t _abs_secondary_axis;
         Gesture::Config _config;
     };
 }}

--- a/src/logid/actions/gesture/ThresholdGesture.cpp
+++ b/src/logid/actions/gesture/ThresholdGesture.cpp
@@ -30,27 +30,22 @@ void ThresholdGesture::press(bool init_threshold)
     this->_executed = false;
 }
 
-void ThresholdGesture::release(bool primary)
+bool ThresholdGesture::release()
 {
-    (void)primary; // Suppress unused warning
-    
     this->_executed = false;
+    return _executed;
 }
 
-void ThresholdGesture::move(int16_t axis)
+void ThresholdGesture::move(int16_t axis, int16_t secondary_axis)
 {
+    (void)secondary_axis; // Suppress unused warning
     _axis += axis;
 
-    if(!this->_executed && metThreshold()) {
+    if(!this->_executed && _axis >= _config.threshold()) {
         _config.action()->press();
         _config.action()->release();
         this->_executed = true;
     }
-}
-
-bool ThresholdGesture::metThreshold() const
-{
-    return _axis >= _config.threshold();
 }
 
 bool ThresholdGesture::wheelCompatibility() const

--- a/src/logid/actions/gesture/ThresholdGesture.cpp
+++ b/src/logid/actions/gesture/ThresholdGesture.cpp
@@ -27,21 +27,21 @@ ThresholdGesture::ThresholdGesture(Device *device, libconfig::Setting &root) :
 void ThresholdGesture::press(bool init_threshold)
 {
     _axis = init_threshold ? _config.threshold() : 0;
+    _abs_secondary_axis = 0;
     this->_executed = false;
 }
 
 bool ThresholdGesture::release()
 {
-    this->_executed = false;
-    return _executed;
+    return this->_executed;
 }
 
 void ThresholdGesture::move(int16_t axis, int16_t secondary_axis)
 {
-    (void)secondary_axis; // Suppress unused warning
     _axis += axis;
+    _abs_secondary_axis += abs(secondary_axis);
 
-    if(!this->_executed && _axis >= _config.threshold()) {
+    if(!this->_executed && _axis >= _config.threshold() && _axis > _abs_secondary_axis) {
         _config.action()->press();
         _config.action()->release();
         this->_executed = true;

--- a/src/logid/actions/gesture/ThresholdGesture.h
+++ b/src/logid/actions/gesture/ThresholdGesture.h
@@ -29,10 +29,8 @@ namespace actions
         ThresholdGesture(Device* device, libconfig::Setting& root);
 
         virtual void press(bool init_threshold=false);
-        virtual void release(bool primary=false);
-        virtual void move(int16_t axis);
-
-        virtual bool metThreshold() const;
+        virtual bool release();
+        virtual void move(int16_t axis, int16_t secondary_axis);
 
         virtual bool wheelCompatibility() const;
 

--- a/src/logid/actions/gesture/ThresholdGesture.h
+++ b/src/logid/actions/gesture/ThresholdGesture.h
@@ -36,6 +36,7 @@ namespace actions
 
     protected:
         int16_t _axis;
+        int16_t _abs_secondary_axis;
         Gesture::Config _config;
 
     private:

--- a/src/logid/features/HiresScroll.cpp
+++ b/src/logid/features/HiresScroll.cpp
@@ -128,7 +128,7 @@ void HiresScroll::_handleScroll(hidpp20::HiresScroll::WheelStatus event)
             }
         }
         if(_config.upAction())
-            _config.upAction()->move(event.deltaV);
+            _config.upAction()->move(event.deltaV, 0);
         _last_direction = 1;
     } else if(event.deltaV < 0) {
         if(_last_direction == 1) {
@@ -138,7 +138,7 @@ void HiresScroll::_handleScroll(hidpp20::HiresScroll::WheelStatus event)
             }
         }
         if(_config.downAction())
-            _config.downAction()->move(-event.deltaV);
+            _config.downAction()->move(-event.deltaV, 0);
         _last_direction = -1;
     }
 

--- a/src/logid/features/ThumbWheel.cpp
+++ b/src/logid/features/ThumbWheel.cpp
@@ -149,7 +149,6 @@ void ThumbWheel::_handleEvent(hidpp20::ThumbWheel::ThumbwheelEvent event)
                 scroll_action = _config.leftAction();
 
             if(scroll_action) {
-                scroll_action->press(true);
                 scroll_action->move(direction * event.rotation, 0);
             }
 

--- a/src/logid/features/ThumbWheel.cpp
+++ b/src/logid/features/ThumbWheel.cpp
@@ -150,7 +150,7 @@ void ThumbWheel::_handleEvent(hidpp20::ThumbWheel::ThumbwheelEvent event)
 
             if(scroll_action) {
                 scroll_action->press(true);
-                scroll_action->move(direction * event.rotation);
+                scroll_action->move(direction * event.rotation, 0);
             }
 
             _last_direction = direction;


### PR DESCRIPTION
The problem:
- I like to map up and down gesture to volume and left and right gesture to zoom. However, sometimes when I'm adjusting volume, zooming would be triggered. This does not happen on LogiOptions.
- Sometimes I overshoot the volume control and would like to move the other way to bring my volume to the desired value. On LogiOptions I can simply move the other way, but with logiops I have to move all the way back to origin or release and press the gesture button again to adjust volume the other way.

This PR fixes the first problem by passing both x and y movement to Gesture classes as primary and secondary axis. Then each Gesture classes can add their own logic to determine whether itself is the indented gesture or not.

New behavior of each type of gestures:
- ReleaseGesture and ThresholdGesture will only be triggered if the total distance moved towards the primary direction is larger than the sum of all absolute value of secondary axis movement.
- IntervalGesture will only be triggered if the sum of all absolute value of primary axis movement is larger than the sum of all absolute value of secondary axis movement.

This PR fixes the second problem trivially by only increasing `_axis` when primary axis movement is positive.

I've also made noneAction trigger even if some threshold are met as long as no actions have been performed by any of the gesture. This let me set the threshold to 1 for my interval gestures. I also think this makes more sense.

~~The behavior for scroll wheel should be unmodified though I have not tested this.~~
Edit: The behavior for scroll wheel is unchanged. The thumb wheel was broken for interval > 8 because press() was called immediately before move(). I removed that line to fix it.

I marked this PR previously as Help Wanted because I am not sure about the desirable behavior for AxisGesture. I'm concerned about the rare (possibly non existent) use case of mapping Left to a AxisGesture and Right to something else such as a ReleaseGesture or even an IntervalGesture. Should I make it similar to IntervalGesture where only positive movement will be recorded? Should I add false positive prevention like I did in IntervalGesture? What is the indented use case for this gesture? What's @PixlOne and everyone else's opinion on this?

Edit: For now I'll be leaving AxisGesture's behavior unchanged as I don't know its common use case and don't want to break someone else's workflow. Personally I think we should make it similar to IntervalGesture (i.e. only record positive movement and have false positive prevention) for consistency sake. However, I'm open to suggestions.

Thank you