### PR TITLE
feat: added action to toggle both smartshift and hires scroll

### DIFF
--- a/src/logid/CMakeLists.txt
+++ b/src/logid/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(logid
         actions/NullAction.cpp
         actions/KeypressAction.cpp
         actions/ToggleHiresScroll.cpp
+        actions/ToggleHiresScrollAndSmartShift.cpp
         actions/ToggleSmartShift.cpp
         actions/CycleDPI.cpp
         actions/ChangeDPI.cpp

--- a/src/logid/actions/Action.cpp
+++ b/src/logid/actions/Action.cpp
@@ -22,6 +22,7 @@
 #include "KeypressAction.h"
 #include "ToggleSmartShift.h"
 #include "ToggleHiresScroll.h"
+#include "ToggleHiresScrollAndSmartShift.h"
 #include "GestureAction.h"
 #include "NullAction.h"
 #include "CycleDPI.h"
@@ -58,6 +59,8 @@ std::shared_ptr<Action> Action::makeAction(Device *device, libconfig::Setting
             return std::make_shared<ToggleSmartShift>(device);
         else if(type == "togglehiresscroll")
             return std::make_shared<ToggleHiresScroll>(device);
+        else if(type == "togglehiresscrollandsmartshift")
+            return std::make_shared<ToggleHiresScrollAndSmartShift>(device);
         else if(type == "gestures")
             return std::make_shared<GestureAction>(device, setting);
         else if(type == "cycledpi")

--- a/src/logid/actions/ToggleHiresScrollAndSmartShift.cpp
+++ b/src/logid/actions/ToggleHiresScrollAndSmartShift.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2019-2020 PixlOne
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#include "ToggleHiresScrollAndSmartShift.h"
+#include "../Device.h"
+#include "../util/task.h"
+#include "../backend/hidpp20/features/ReprogControls.h"
+
+using namespace logid::actions;
+using namespace logid::backend;
+
+ToggleHiresScrollAndSmartShift::ToggleHiresScrollAndSmartShift(Device *dev) : Action (dev)
+{
+    _hires_scroll = _device->getFeature<features::HiresScroll>("hiresscroll");
+    if(!_hires_scroll)
+        logPrintf(WARN, "%s:%d: HiresScroll feature not found, cannot use "
+                        "ToggleHiresScroll action.",
+                  _device->hidpp20().devicePath().c_str(),
+                  _device->hidpp20().devicePath().c_str());
+    
+    _smartshift = _device->getFeature<features::SmartShift>("smartshift");
+    if(!_smartshift)
+        logPrintf(WARN, "%s:%d: SmartShift feature not found, cannot use "
+                        "ToggleSmartShift action.",
+                        _device->hidpp20().devicePath().c_str(),
+                        _device->hidpp20().deviceIndex());
+}
+
+void ToggleHiresScrollAndSmartShift::press()
+{
+    _pressed = true;
+    if(_hires_scroll)
+    {
+        task::spawn([hires=this->_hires_scroll](){
+            auto mode = hires->getMode();
+            mode ^= backend::hidpp20::HiresScroll::HiRes;
+            hires->setMode(mode);
+        });
+    }
+
+    if(_smartshift) {
+        task::spawn([ss=this->_smartshift](){
+            auto status = ss->getStatus();
+            status.setActive = true;
+            status.active = !status.active;
+            ss->setStatus(status);
+        });
+    }
+}
+
+void ToggleHiresScrollAndSmartShift::release()
+{
+    _pressed = false;
+}
+
+uint8_t ToggleHiresScrollAndSmartShift::reprogFlags() const
+{
+    return hidpp20::ReprogControls::TemporaryDiverted;
+}

--- a/src/logid/actions/ToggleHiresScrollAndSmartShift.h
+++ b/src/logid/actions/ToggleHiresScrollAndSmartShift.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019-2020 PixlOne
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#ifndef LOGID_ACTION_TOGGLEHIRESSCROLLANDSMARTSHIFT_H
+#define LOGID_ACTION_TOGGLEHIRESSCROLLANDSMARTSHIFT_H
+
+#include "Action.h"
+#include "../features/HiresScroll.h"
+#include "../features/SmartShift.h"
+
+namespace logid {
+namespace actions
+{
+    class ToggleHiresScrollAndSmartShift : public Action
+    {
+    public:
+        explicit ToggleHiresScrollAndSmartShift(Device* dev);
+
+        virtual void press();
+        virtual void release();
+
+        virtual uint8_t reprogFlags() const;
+    protected:
+        std::shared_ptr<features::HiresScroll> _hires_scroll;
+        std::shared_ptr<features::SmartShift> _smartshift;
+    };
+}}
+
+#endif //LOGID_ACTION_TOGGLEHIRESSCROLLANDSMARTSHIFT_H


### PR DESCRIPTION
Thanks to this commit it is possible to trigger the ToggleHiresScrollAndSmartShift action (I'm open to better naming), useful to enable hires scroll only when smartshift is enabled.