### PR TITLE
Fix c++2a compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,18 +13,18 @@ Default location for the configuration file is /etc/logid.cfg, but another can b
 
 ## Dependencies
 
-This project requires a C++17 compiler, `cmake`, `libevdev`, `libudev`, `glib`, and `libconfig`.
+This project requires a C++20 compiler, `cmake`, `libevdev`, `libudev`, `glib`, and `libconfig`.
 For popular distributions, I've included commands below.
 
-**Arch Linux:** `sudo pacman -S cmake libevdev libconfig pkgconf glib2`
+**Arch Linux:** `sudo pacman -S base-devel cmake g++ libevdev libconfig pkgconf glib2`
 
-**Debian/Ubuntu:** `sudo apt install cmake libevdev-dev libudev-dev libconfig++-dev libglib2.0`
+**Debian/Ubuntu:** `sudo apt install git cmake g++ libevdev-dev libudev-dev libconfig++-dev libglib2.0-dev`
 
 **Fedora:** `sudo dnf install cmake libevdev-devel systemd-devel libconfig-devel gcc-c++ glib2`
 
 **Gentoo Linux:** `sudo emerge dev-libs/libconfig dev-libs/libevdev dev-libs/glib dev-util/cmake virtual/libudev`
 
-**Solus:** `sudo eopkg install libevdev-devel libconfig-devel libgudev-devel glib2`
+**Solus:** `sudo eopkg install cmake libevdev-devel libconfig-devel libgudev-devel glib2`
 
 **openSUSE:** `sudo zypper install cmake libevdev-devel systemd-devel libconfig-devel gcc-c++ libconfig++-devel libudev-devel glib2`
 

--- a/src/logid/CMakeLists.txt
+++ b/src/logid/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(PkgConfig REQUIRED)
 add_executable(logid
         logid.cpp
         util/log.cpp
-        config/util.cpp
+        config/config.cpp
         InputDevice.cpp
         DeviceManager.cpp
         Device.cpp

--- a/src/logid/config/config.cpp
+++ b/src/logid/config/config.cpp
@@ -16,10 +16,14 @@
  *
  */
 
-#include <config/types.h>
+#include <config/schema.h>
 #include <util/log.h>
 
 using namespace logid;
+
+const char config::keys::name[] = "name";
+const char config::keys::cid[] = "cid";
+const char config::keys::direction[] = "direction";
 
 void config::logError(const libconfig::Setting& setting, std::exception& e) {
     logPrintf(WARN, "Error at line %d: %s", setting.getSourceLine(), e.what());

--- a/src/logid/config/map.h
+++ b/src/logid/config/map.h
@@ -24,13 +24,11 @@
 #include <utility>
 
 namespace logid::config {
-    template<size_t N>
-    struct string_literal {
-        constexpr string_literal(const char (& str)[N]) {
-            std::copy_n(str, N, value);
-        }
+    struct string_literal { };
 
-        char value[N]{};
+    template<const char* str>
+    struct string_literal_of : public string_literal {
+        constexpr static const char* value = str;
     };
 
     template<class T>
@@ -46,10 +44,12 @@ namespace logid::config {
     };
 
     // Warning: map must be a variant of groups or a group
-    template<typename K, typename V, string_literal KeyName,
+    template<typename K, typename V, typename KeyName,
             typename Compare=typename std::map<K, V>::key_compare,
             typename Allocator=typename std::map<K, V>::allocator_type>
     class map : public std::map<K, V, Compare, Allocator> {
+        static_assert(std::is_base_of<string_literal, KeyName>::value,
+                "KeyName must be a string_literal");
     public:
         template<typename... Args>
         explicit map(Args... args) :

--- a/src/logid/config/schema.h
+++ b/src/logid/config/schema.h
@@ -51,6 +51,11 @@ namespace logid::actions {
 }
 
 namespace logid::config {
+    struct keys {
+        static const char name[];
+        static const char cid[];
+        static const char direction[];
+    };
 
     struct NoAction : public signed_group<std::string> {
         typedef actions::NullAction action;
@@ -213,7 +218,7 @@ namespace logid::config {
 
     struct GestureAction : public signed_group<std::string> {
         typedef actions::GestureAction action;
-        std::optional<map<std::string, Gesture, "direction",
+        std::optional<map<std::string, Gesture, string_literal_of<keys::direction>,
                 less_caseless<std::string>>> gestures;
 
         GestureAction() : signed_group<std::string>(
@@ -284,7 +289,7 @@ namespace logid::config {
                              &ThumbWheel::tap) {}
     };
 
-    typedef map<uint16_t, Button, "cid"> RemapButton;
+    typedef map<uint16_t, Button, string_literal_of<keys::cid>> RemapButton;
 
     struct Profile : public group {
         std::optional<DPI> dpi;
@@ -302,7 +307,7 @@ namespace logid::config {
 
     struct Device : public group {
         ipcgull::property<std::string> default_profile;
-        map<std::string, Profile, "name"> profiles;
+        map<std::string, Profile, string_literal_of<keys::name>> profiles;
 
         Device() : group({"default_profile", "profiles"},
                          &Device::default_profile,
@@ -313,7 +318,7 @@ namespace logid::config {
 
     struct Config : public group {
         std::optional<map<std::string,
-                std::variant<Device, Profile>, "name">> devices;
+                std::variant<Device, Profile>, string_literal_of<keys::name>>> devices;
         std::optional<std::set<uint16_t>> ignore;
         std::optional<double> io_timeout;
         std::optional<int> workers;

--- a/src/logid/config/types.h
+++ b/src/logid/config/types.h
@@ -349,7 +349,7 @@ namespace logid::config {
             }
         };
 
-        template<typename K, typename V, string_literal KeyName,
+        template<typename K, typename V, typename KeyName,
                 typename Cmp, typename Alloc>
         struct config_io<map<K, V, KeyName, Cmp, Alloc>> {
             static inline map<K, V, KeyName, Cmp, Alloc> get(
@@ -359,7 +359,7 @@ namespace logid::config {
                 for (int i = 0; i < size; ++i) {
                     auto& s = setting[i];
                     try {
-                        t.emplace(config_io<K>::get(s.lookup(KeyName.value)),
+                        t.emplace(config_io<K>::get(s.lookup(KeyName::value)),
                                   config_io<V>::get(s));
                     } catch (libconfig::SettingException& e) {}
                 }
@@ -378,7 +378,7 @@ namespace logid::config {
                 for (auto& x: t) {
                     auto& s = setting.add(libconfig::Setting::TypeGroup);
                     config_io<V>::set(s, x.second);
-                    config_io<K>::set(s, KeyName.value, x.first);
+                    config_io<K>::set(s, KeyName::value, x.first);
                 }
             }
 


### PR DESCRIPTION
Adds gcc 9 support and fixes builds on Ubuntu 20.04, fixes #367 