### PR TITLE
Remove check if DBus is found

### DIFF
--- a/src/logid/CMakeLists.txt
+++ b/src/logid/CMakeLists.txt
@@ -72,7 +72,6 @@ add_executable(logid
 set_target_properties(logid PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
 pkg_check_modules(PC_EVDEV libevdev REQUIRED)
-pkg_check_modules(DBUS "dbus-1")
 pkg_check_modules(SYSTEMD "systemd")
 pkg_check_modules(LIBCONFIG libconfig REQUIRED)
 pkg_check_modules(LIBUDEV libudev REQUIRED)
@@ -111,13 +110,11 @@ elseif (NOT SYSTEMD_FOUND AND SYSTEMD_SERVICES_INSTALL_DIR)
     message(FATAL_ERROR "systemd is not found w/ pkg-config but SYSTEMD_SERVICES_INSTALL_DIR is defined.")
 endif ()
 
-if(DBUS_FOUND)
-    # Install DBus conf
-    # TODO: Is there a better way of setting the system policy directory?
-    set(DBUS_SYSTEM_POLICY_INSTALL_DIR "/usr/share/dbus-1/system.d")
-    configure_file(logiops-dbus.conf.in ${CMAKE_BINARY_DIR}/pizza.pixl.LogiOps.conf)
-    message(STATUS "dbus system policy will be installed at ${DBUS_SYSTEM_POLICY_INSTALL_DIR}")
-    install(FILES ${CMAKE_BINARY_DIR}/pizza.pixl.LogiOps.conf
-            DESTINATION ${DBUS_SYSTEM_POLICY_INSTALL_DIR}
-            COMPONENT cp)
-endif()
+# Install DBus conf
+# TODO: Is there a better way of setting the system policy directory?
+set(DBUS_SYSTEM_POLICY_INSTALL_DIR "/usr/share/dbus-1/system.d")
+configure_file(logiops-dbus.conf.in ${CMAKE_BINARY_DIR}/pizza.pixl.LogiOps.conf)
+message(STATUS "dbus system policy will be installed at ${DBUS_SYSTEM_POLICY_INSTALL_DIR}")
+install(FILES ${CMAKE_BINARY_DIR}/pizza.pixl.LogiOps.conf
+        DESTINATION ${DBUS_SYSTEM_POLICY_INSTALL_DIR}
+        COMPONENT cp)


### PR DESCRIPTION
Broken on Ubuntu and leads to DBus policy not being installed, DBus is required anyways right now so remove this check. Fixes #371.