### PR TITLE
Add quotes to device name log

### DIFF
--- a/src/logid/Device.cpp
+++ b/src/logid/Device.cpp
@@ -138,7 +138,7 @@ Device::Device(Receiver* receiver, hidpp::DeviceIndex index,
 }
 
 void Device::_init() {
-    logPrintf(INFO, "Device found: %s on %s:%d", name().c_str(),
+    logPrintf(INFO, "Device found: \"%s\" on %s:%d", name().c_str(),
               hidpp20().devicePath().c_str(), _index);
 
     {


### PR DESCRIPTION
Otherwise it's hard to see trailing whitespaces. Perhaps it's better to strip them instead. In device name and config file.