### PR TITLE
GestureAction: Add scroll support

### DIFF
--- a/src/logid/actions/Action.h
+++ b/src/logid/actions/Action.h
@@ -71,6 +71,11 @@ namespace logid::actions {
 
         virtual void move([[maybe_unused]] int16_t x, [[maybe_unused]] int16_t y) { }
 
+        virtual void scroll(int16_t s) {
+            // Suppress unused warning
+            (void)s;
+        };
+
         virtual bool pressed() {
             return _pressed;
         }

--- a/src/logid/actions/GestureAction.h
+++ b/src/logid/actions/GestureAction.h
@@ -32,14 +32,16 @@ namespace logid::actions {
             Up,
             Down,
             Left,
-            Right
+            Right,
+            ScrollUp,
+            ScrollDown,
         };
 
         static Direction toDirection(std::string direction);
 
         static std::string fromDirection(Direction direction);
 
-        static Direction toDirection(int32_t x, int32_t y);
+        Direction toDirection(int32_t x, int32_t y, int16_t s);
 
         GestureAction(Device* dev, config::GestureAction& config,
                       const std::shared_ptr<ipcgull::node>& parent);
@@ -48,7 +50,13 @@ namespace logid::actions {
 
         void release() final;
 
-        void move(int16_t x, int16_t y) final;
+        void move(int16_t x, int16_t y) final {
+            move3D(x, y, 0);
+        };
+
+        void scroll(int16_t s) {
+            move3D(0, 0, s);
+        };
 
         uint8_t reprogFlags() const final;
 
@@ -56,10 +64,19 @@ namespace logid::actions {
                         const std::string& type);
 
     protected:
-        int32_t _x{}, _y{};
+        int32_t _x{}, _y{}, _s{};
         std::shared_ptr<ipcgull::node> _node;
         std::map<Direction, std::shared_ptr<Gesture>> _gestures;
         config::GestureAction& _config;
+
+        bool isScroll();
+
+        bool isVertical();
+
+        bool isHorizontal();
+
+    private:
+        void move3D(int16_t, int16_t, int16_t);
     };
 }
 

--- a/src/logid/features/HiresScroll.cpp
+++ b/src/logid/features/HiresScroll.cpp
@@ -16,6 +16,7 @@
  *
  */
 #include <features/HiresScroll.h>
+#include <features/RemapButton.h>
 #include <actions/gesture/AxisGesture.h>
 #include <Device.h>
 #include <InputDevice.h>
@@ -152,6 +153,9 @@ void HiresScroll::_fixGesture(const std::shared_ptr<actions::Gesture>& gesture) 
 }
 
 void HiresScroll::_handleScroll(hidpp20::HiresScroll::WheelStatus event) {
+    auto remapbutton = _device->getFeature<features::RemapButton>("remapbutton");
+    if (remapbutton && remapbutton->onHiresScroll(event.deltaV)) return;
+
     std::shared_lock lock(_config_mutex);
     auto now = std::chrono::system_clock::now();
     if (std::chrono::duration_cast<std::chrono::seconds>(now - _last_scroll).count() >= 1) {

--- a/src/logid/features/RemapButton.cpp
+++ b/src/logid/features/RemapButton.cpp
@@ -150,6 +150,17 @@ void RemapButton::setProfile(config::Profile& profile) {
         button.second->setProfile(config[button.first]);
 }
 
+bool RemapButton::onHiresScroll(int16_t deltaV)
+{
+    bool handled = false;
+    for (const auto& button: _buttons)
+        if (button.second->pressed()) {
+            button.second->getAction()->scroll(deltaV);
+                handled = true;
+        }
+    return handled;
+}
+
 void RemapButton::_buttonEvent(const std::set<uint16_t>& new_state) {
     // Ensure I/O doesn't occur while updating button state
     std::lock_guard<std::mutex> lock(_button_lock);

--- a/src/logid/features/RemapButton.h
+++ b/src/logid/features/RemapButton.h
@@ -50,6 +50,10 @@ namespace logid::features {
 
         bool pressed() const;
 
+        auto getAction() const {
+            return _action;
+        };
+
     private:
         friend class ButtonWrapper;
 
@@ -96,6 +100,8 @@ namespace logid::features {
         void listen() final;
 
         void setProfile(config::Profile& profile) final;
+
+        bool onHiresScroll(int16_t);
 
     protected:
         explicit RemapButton(Device* dev);


### PR DESCRIPTION
Allow users to use vertical scroll wheel rotation in gestures (for zooming in/out, volume control and so on).

The original code belongs to abraha2d (https://github.com/abraha2d/logiops/tree/scroll-support), I just have ported it to logiops v0.3.2