### PR TITLE
Resolve deadlocking when adding to IOMonitor

### DIFF
--- a/src/logid/DeviceManager.cpp
+++ b/src/logid/DeviceManager.cpp
@@ -66,11 +66,11 @@ void DeviceManager::addDevice(std::string path) {
 
     // Check if device is ignored before continuing
     {
-        raw::RawDevice raw_dev(path, self<DeviceManager>().lock());
+        auto raw_dev = raw::RawDevice::make(path, self<DeviceManager>().lock());
         if (config()->ignore.has_value() &&
-            config()->ignore.value().contains(raw_dev.productId())) {
+            config()->ignore.value().contains(raw_dev->productId())) {
             logPrintf(DEBUG, "%s: Device 0x%04x ignored.",
-                      path.c_str(), raw_dev.productId());
+                      path.c_str(), raw_dev->productId());
             return;
         }
     }

--- a/src/logid/backend/hidpp/Device.cpp
+++ b/src/logid/backend/hidpp/Device.cpp
@@ -53,7 +53,7 @@ Device::Device(const std::string& path, DeviceIndex index,
                const std::shared_ptr<raw::DeviceMonitor>& monitor, double timeout) :
         io_timeout(duration_cast<milliseconds>(
                 duration<double, std::milli>(timeout))),
-        _raw_device(std::make_shared<raw::RawDevice>(path, monitor)),
+        _raw_device(raw::RawDevice::make(path, monitor)),
         _receiver(nullptr), _path(path), _index(index) {
 }
 

--- a/src/logid/backend/raw/RawDevice.cpp
+++ b/src/logid/backend/raw/RawDevice.cpp
@@ -117,11 +117,22 @@ RawDevice::RawDevice(std::string path, const std::shared_ptr<DeviceMonitor>& mon
         auto phys = get_phys(_fd);
         _sub_device = std::regex_match(phys, virtual_path_regex);
     }
+}
 
+void RawDevice::_ready() {
     _io_monitor->add(_fd, {
-            [this]() { _readReports(); },
-            [this]() { _valid = false; },
-            [this]() { _valid = false; }
+            [self_weak = _self]() {
+                if (auto self = self_weak.lock())
+                    self->_readReports();
+            },
+            [self_weak = _self]() {
+                if (auto self = self_weak.lock())
+                    self->_valid = false;
+            },
+            [self_weak = _self]() {
+                if (auto self = self_weak.lock())
+                    self->_valid = false;
+            }
     });
 }
 


### PR DESCRIPTION
Do not lock run_mutex while running an I/O handler.