### PR TITLE
fix bug: represent cid as `uint16_t`, not `uint8_t`

### DIFF
--- a/src/logid/backend/hidpp20/features/ReprogControls.cpp
+++ b/src/logid/backend/hidpp20/features/ReprogControls.cpp
@@ -129,7 +129,7 @@ ReprogControls::ControlInfo ReprogControls::getControlIdInfo(uint16_t cid) {
     return report;
 }
 
-void ReprogControls::setControlReporting(uint8_t cid, ControlInfo info) {
+void ReprogControls::setControlReporting(uint16_t cid, ControlInfo info) {
     // This function does not exist pre-v4 and cannot be emulated, ignore.
     (void) cid;
     (void) info; // Suppress unused warnings
@@ -173,7 +173,7 @@ ReprogControls::ControlInfo ReprogControlsV4::getControlReporting(uint16_t cid) 
     return info;
 }
 
-void ReprogControlsV4::setControlReporting(uint8_t cid, ControlInfo info) {
+void ReprogControlsV4::setControlReporting(uint16_t cid, ControlInfo info) {
     std::vector<uint8_t> params(5);
     params[0] = (cid >> 8) & 0xff;
     params[1] = cid & 0xff;

--- a/src/logid/backend/hidpp20/features/ReprogControls.h
+++ b/src/logid/backend/hidpp20/features/ReprogControls.h
@@ -100,7 +100,7 @@ namespace logid::backend::hidpp20 {
         [[nodiscard]] virtual ControlInfo getControlReporting(uint16_t cid);
 
         // Only controlId (for remap) and flags will be read
-        virtual void setControlReporting(uint8_t cid, ControlInfo info);
+        virtual void setControlReporting(uint16_t cid, ControlInfo info);
 
         [[nodiscard]] static std::set<uint16_t> divertedButtonEvent(const hidpp::Report& report);
 
@@ -162,7 +162,7 @@ namespace logid::backend::hidpp20 {
 
         [[nodiscard]] ControlInfo getControlReporting(uint16_t cid) override;
 
-        void setControlReporting(uint8_t cid, ControlInfo info) override;
+        void setControlReporting(uint16_t cid, ControlInfo info) override;
 
         explicit ReprogControlsV4(Device* dev);
 


### PR DESCRIPTION
Fixes: #406
The problem description is in the referenced issue.

## Diagnosis

The function `ReprogControlsV4::setControlReporting()` erroneously took `cid` as `uint8_t`. Because of that, reports contained only lower byte of any cid, so any ReprogControls request for such cid resulted in error response. Lack of error response handling in this library led to timeout.

E.g.:
```
[DEBUG] Configuring button: 0x103
[RAWREPORT] /dev/hidraw1 OUT: 11 ff 08 32 00 03 22 01 03 00 00 00 00 00 00 00 00 00 00 00
[RAWREPORT] /dev/hidraw1 IN:  11 ff ff 08 32 02 00 00 00 00 00 00 00 00 00 00 00 00 00 00
```
We can see only lower byte (03) of `cid` present. Thus we get an error response (with feature id `ff`), but the logiops keeps waiting for response with feature id `08` and hence eventually timeouts.

## Solution

`ReprogControlsV4::setControlReporting()` was modified to take `cid` as `uint16_t`.