### PR TITLE
Add include <algorithm> to fix building with gcc 14

### DIFF
--- a/src/logid/config/group.h
+++ b/src/logid/config/group.h
@@ -22,6 +22,7 @@
 #include <type_traits>
 #include <functional>
 #include <utility>
+#include <algorithm>
 
 namespace logid::config {
     template<typename T>


### PR DESCRIPTION
With gcc 14 some C++ Standard Library headers have been changed to no longer include other headers that were being used internally by the library. In logiops's case it is the `<algorithm>` header.

[Downstream Gentoo bug](https://bugs.gentoo.org/917002)

[GCC 14 porting guide](https://gcc.gnu.org/gcc-14/porting_to.html)