### PR TITLE
Bolt receiver support patch

### DIFF
--- a/src/logid/backend/hidpp10/ReceiverMonitor.cpp
+++ b/src/logid/backend/hidpp10/ReceiverMonitor.cpp
@@ -158,7 +158,6 @@ void ReceiverMonitor::enumerate() {
 }
 
 void ReceiverMonitor::waitForDevice(hidpp::DeviceIndex index) {
-    const std::lock_guard lock(_wait_mutex);
     if (!_waiters.count(index)) {
         _waiters.emplace(index, _receiver->rawDevice()->addEventHandler(
                 {[index](const std::vector<uint8_t>& report) -> bool {
@@ -219,9 +218,8 @@ void ReceiverMonitor::_stopPair() {
 void ReceiverMonitor::_addHandler(const hidpp::DeviceConnectionEvent& event, int tries) {
     auto device_path = _receiver->devicePath();
     try {
-        addDevice(event);
-        const std::lock_guard lock(_wait_mutex);
         _waiters.erase(event.index);
+        addDevice(event);
     } catch (DeviceNotReady& e) {
         if (tries == max_tries) {
             logPrintf(WARN, "Failed to add device %s:%d after %d tries."


### PR DESCRIPTION
I am creating this PR on behalf of @xinix00 in issue #402.

This patch fixes an issue where connecting to a device through the bolt receiver failed. This patch fixes issue #402, #388 and #385. Multiple people have been affected and have been helped by that fix. Hope this can be applied to all.