### PR TITLE
Fix CVE-2024-45752

### DIFF
--- a/src/logid/logiops-dbus.conf.in
+++ b/src/logid/logiops-dbus.conf.in
@@ -3,11 +3,12 @@
  "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
 
 <busconfig>
-  <policy user="root">
-    <allow own="pizza.pixl.LogiOps"/>
+  <policy context="default">
+    <deny receive_sender="pizza.pixl.LogiOps"/>
   </policy>
 
-  <policy context="default">
+  <policy user="root">
+    <allow own="pizza.pixl.LogiOps"/>
     <allow send_destination="pizza.pixl.LogiOps"/>
     <allow receive_sender="pizza.pixl.LogiOps"/>
   </policy>


### PR DESCRIPTION
Prevents arbitrary users from accessing d-bus interface. Fixes #473. This change now requires any application using the LogiOps D-Bus interface to run as root.

In the future, a more comprehensive permission system will be added.