### PR TITLE
Guard device adding and removing with mutex

### DIFF
--- a/src/logid/backend/raw/DeviceMonitor.cpp
+++ b/src/logid/backend/raw/DeviceMonitor.cpp
@@ -157,10 +157,12 @@ void DeviceMonitor::_addHandler(const std::string& device, int tries) {
     try {
         auto supported_reports = backend::hidpp::getSupportedReports(
                 RawDevice::getReportDescriptor(device));
-        if (supported_reports)
+        if (supported_reports) {
+            std::lock_guard<std::mutex> lock(_devices_mutex);
             addDevice(device);
-        else
+        } else {
             logPrintf(DEBUG, "Unsupported device %s ignored", device.c_str());
+        }
     } catch (backend::DeviceNotReady& e) {
         if (tries == max_tries) {
             logPrintf(WARN, "Failed to add device %s after %d tries. Treating as failure.",
@@ -182,6 +184,7 @@ void DeviceMonitor::_addHandler(const std::string& device, int tries) {
 
 void DeviceMonitor::_removeHandler(const std::string& device) {
     try {
+        std::lock_guard<std::mutex> lock(_devices_mutex);
         removeDevice(device);
     } catch (std::exception& e) {
         logPrintf(WARN, "Error removing device %s: %s",

--- a/src/logid/backend/raw/DeviceMonitor.h
+++ b/src/logid/backend/raw/DeviceMonitor.h
@@ -95,6 +95,8 @@ namespace logid::backend::raw {
         bool _ready;
 
         std::weak_ptr<DeviceMonitor> _self;
+
+        mutable std::mutex _devices_mutex;
     };
 }
 


### PR DESCRIPTION
It looks like Udev might retrigger device adding on enumeration phase which causes addDevice() to be called twice on the same device at the same time or too fast.

Adding a mutex to prevent this, so
DeviceManager::addDevice() is not
ran concurrently.

Here are some logs from `journalctl`

## Before changes:

```
Mar 07 16:38:31 my-laptop.local systemd[1]: Started logid.service - Logitech Configuration Daemon.
Mar 07 16:49:14 my-laptop.local logid[2990]: [INFO] Detected receiver at /dev/hidraw8
Mar 07 16:49:45 my-laptop.local logid[2990]: [INFO] Device found: MX Keys Mini on /dev/hidraw8:1
Mar 07 16:50:42 my-laptop.local logid[2990]: [WARN] Failed to add device /dev/hidraw9 after 5 tries. Treating as failure.
Mar 07 16:50:42 my-laptop.local logid[2990]: [WARN] Failed to add device /dev/hidraw9 after 5 tries. Treating as failure.
```

### When restarting the service, all OK
```
Mar 07 16:51:20 my-laptop.local systemd[1]: Started logid.service - Logitech Configuration Daemon.
Mar 07 16:51:20 my-laptop.local logid[15190]: [INFO] Detected receiver at /dev/hidraw8
Mar 07 16:51:21 my-laptop.local logid[15190]: [INFO] Device found: Wireless Mouse MX Master 3 on /dev/hidraw9:255
```

### When adding more logs, I see _addHandler() called twice, and keeps repeating on same timestamp
```
Jul 21 11:39:27 my-laptop.local kernel: input: MX Master 3 Keyboard as /devices/virtual/misc/uhid/0005:046D:B023.000A/input/input27
Jul 21 11:39:27 my-laptop.local kernel: input: MX Master 3 Mouse as /devices/virtual/misc/uhid/0005:046D:B023.000A/input/input28
Jul 21 11:39:27 my-laptop.local kernel: hid-generic 0005:046D:B023.000A: input,hidraw9: BLUETOOTH HID v0.15 Keyboard [MX Master 3] on c8:58:b3:4e:e3:72
Jul 21 11:39:27 my-laptop.local kernel: input: Logitech Wireless Mouse MX Master 3 as /devices/virtual/misc/uhid/0005:046D:B023.000A/input/input30
Jul 21 11:39:27 my-laptop.local kernel: logitech-hidpp-device 0005:046D:B023.000A: input,hidraw9: BLUETOOTH HID v0.15 Keyboard [Logitech Wireless Mouse MX Master >
Jul 21 11:39:27 my-laptop.local kernel: logitech-hidpp-device 0005:046D:B023.000A: HID++ 4.5 device connected.
Jul 21 11:39:28 my-laptop.local gnome-shell[3886]: Could not open device /dev/input/event23: Could not get device info for path /dev/input/event23: No such file o>
Jul 21 11:39:28 my-laptop.local logid[3530]: [INFO] _io_monitor(add)
Jul 21 11:39:28 my-laptop.local logid[3530]: [INFO] _addHandler(/dev/hidraw9)
Jul 21 11:39:28 my-laptop.local logid[3530]: [INFO] _io_monitor(remove)
Jul 21 11:39:28 my-laptop.local gnome-shell[3886]: Could not open device /dev/input/event22: GDBus.Error:System.Error.ENODEV: No such device
Jul 21 11:39:28 my-laptop.local logid[3530]: [INFO] _io_monitor(add)
Jul 21 11:39:28 my-laptop.local logid[3530]: [INFO] _addHandler(/dev/hidraw9)
Jul 21 11:39:28 my-laptop.local systemd-logind[1941]: Watching system buttons on /dev/input/event22 (Logitech Wireless Mouse MX Master 3)
Jul 21 11:39:28 my-laptop.local logid[3530]: [INFO] _addHandler(/dev/hidraw9)
Jul 21 11:39:28 my-laptop.local logid[3530]: [INFO] _addHandler(/dev/hidraw9)
Jul 21 11:39:30 my-laptop.local logid[3530]: [INFO] _addHandler(/dev/hidraw9)[INFO] _addHandler(/dev/hidraw9)
Jul 21 11:39:32 my-laptop.local logid[3530]: [INFO] _addHandler(/dev/hidraw9)
Jul 21 11:39:32 my-laptop.local logid[3530]: [INFO] _addHandler(/dev/hidraw9)
```

## After adding the mutex, it seem to fix the issue
```
Jul 28 10:58:41 my-laptop.local kernel: input: MX Master 3 Keyboard as /devices/virtual/misc/uhid/0005:046D:B023.000A/input/input27
Jul 28 10:58:41 my-laptop.local kernel: input: MX Master 3 Mouse as /devices/virtual/misc/uhid/0005:046D:B023.000A/input/input28
Jul 28 10:58:41 my-laptop.local kernel: hid-generic 0005:046D:B023.000A: input,hidraw9: BLUETOOTH HID v0.15 Keyboard [MX Master 3] on c8:58:b3:4e:e3:72
Jul 28 10:58:41 my-laptop.local kernel: input: Logitech Wireless Mouse MX Master 3 as /devices/virtual/misc/uhid/0005:046D:B023.000A/input/input30
Jul 28 10:58:41 my-laptop.local kernel: logitech-hidpp-device 0005:046D:B023.000A: input,hidraw9: BLUETOOTH HID v0.15 Keyboard [Logitech Wireless Mouse MX Master >
Jul 28 10:58:41 my-laptop.local kernel: logitech-hidpp-device 0005:046D:B023.000A: HID++ 4.5 device connected.
Jul 28 10:58:41 my-laptop.local gnome-shell[3876]: Could not open device /dev/input/event23: Could not get device info for path /dev/input/event23: No such file o>
Jul 28 10:58:41 my-laptop.local gnome-shell[3876]: Could not open device /dev/input/event22: GDBus.Error:System.Error.ENODEV: No such device
Jul 28 10:58:41 my-laptop.local systemd-logind[1947]: Watching system buttons on /dev/input/event22 (Logitech Wireless Mouse MX Master 3)
Jul 28 10:58:42 my-laptop.local logid[3526]: [INFO] Device found: Wireless Mouse MX Master 3 on /dev/hidraw9:255
Jul 28 10:58:43 my-laptop.local logid[3526]: [INFO] Device on /dev/hidraw9 disconnected
Jul 28 10:58:43 my-laptop.local logid[3526]: [INFO] Device found: Wireless Mouse MX Master 3 on /dev/hidraw9:255
```

I'm unsure if this issue is related to `gnome-shell` doing its own initialization, but definitely it looks like syncronization issue between services. Too many are trying to talk to the same device when its found.

This potentially fixes or affects following issues:
* #279
* #156
* #508
* #492
* #481
* #475

there were many others that mention "on boot", "restart", "delay" and "MX Master 3".
Maybe something else needs also be done for "Device added X", "Device removed X", so that it won't retrigger so fast.
However, this fixes my issue, I hope it helps others.
