### PR TITLE
Fix printing of uint_16t CIDs

### DIFF
--- a/src/logid/features/RemapButton.cpp
+++ b/src/logid/features/RemapButton.cpp
@@ -51,7 +51,9 @@ RemapButton::RemapButton(Device* dev) : DeviceFeature(dev),
     if (!config.has_value())
         config = config::RemapButton();
 
-    for (const auto& control: _reprog_controls->getControls()) {
+    const auto& controls = _reprog_controls->getControls();
+
+    for (const auto& control: controls) {
         const auto i = _buttons.size();
         Button::ConfigFunction func = [this, info = control.second](
                 const std::shared_ptr<actions::Action>& action) {
@@ -83,7 +85,6 @@ RemapButton::RemapButton(Device* dev) : DeviceFeature(dev),
         logPrintf(DEBUG, "%s:%d remappable buttons:",
                   dev->hidpp20().devicePath().c_str(),
                   dev->hidpp20().deviceIndex());
-        const auto& controls = _reprog_controls->getControls();
         int cid_width = controls.rbegin()->first > 0xFF ? 5 : 4;
         logPrintf(DEBUG, "%-*s | reprog? | fn key? | mouse key? | "
                          "gesture support?", cid_width, "CID");

--- a/src/logid/features/RemapButton.cpp
+++ b/src/logid/features/RemapButton.cpp
@@ -63,7 +63,7 @@ RemapButton::RemapButton(Device* dev) : DeviceFeature(dev),
                 if ((action->reprogFlags() & hidpp20::ReprogControls::RawXYDiverted) &&
                     (!_reprog_controls->supportsRawXY() ||
                      !(info.additionalFlags & hidpp20::ReprogControls::RawXY)))
-                    logPrintf(WARN, "%s: 'Cannot divert raw XY movements for CID 0x%02x",
+                    logPrintf(WARN, "%s: Cannot divert raw XY movements for CID 0x%04x",
                               _device->name().c_str(), info.controlID);
 
                 report.flags |= action->reprogFlags();
@@ -83,10 +83,12 @@ RemapButton::RemapButton(Device* dev) : DeviceFeature(dev),
         logPrintf(DEBUG, "%s:%d remappable buttons:",
                   dev->hidpp20().devicePath().c_str(),
                   dev->hidpp20().deviceIndex());
-        logPrintf(DEBUG, "CID  | reprog? | fn key? | mouse key? | "
-                         "gesture support?");
-        for (const auto& control: _reprog_controls->getControls())
-            logPrintf(DEBUG, "0x%02x | %-7s | %-7s | %-10s | %s",
+        const auto& controls = _reprog_controls->getControls();
+        int cid_width = controls.rbegin()->first > 0xFF ? 5 : 4;
+        logPrintf(DEBUG, "%-*s | reprog? | fn key? | mouse key? | "
+                         "gesture support?", cid_width, "CID");
+        for (const auto& control: controls)
+            logPrintf(DEBUG, "0x%0*x | %-7s | %-7s | %-10s | %s", cid_width - 2,
                       control.first, REPROG_FLAG(TemporaryDivertable), REPROG_FLAG(FKey),
                       REPROG_FLAG(MouseButton), REPROG_FLAG_ADDITIONAL(RawXY));
     }


### PR DESCRIPTION
In #414, @wprzytula changed CIDs from `uint8_t` to be `uint16_t` instead, but the code that prints these values was not adapted accordingly. This patch adjust the printing code for CIDs to ensure they consider the wider length of uint_16t's hex representations.

For comparison, here's the output I get with the current v0.3.5 (note the misalignment in the `0x1a0` line of the "remappable buttons" table):

```console
$ sudo logid -v
[DEBUG] Unsupported device /dev/hidraw4 ignored
[DEBUG] Unsupported device /dev/hidraw1 ignored
[DEBUG] Unsupported device /dev/hidraw2 ignored
[DEBUG] Unsupported device /dev/hidraw3 ignored
[DEBUG] Unsupported device /dev/hidraw0 ignored
[INFO] Device found: MX Master 4 on /dev/hidraw5:255
[DEBUG] /dev/hidraw5:255 remappable buttons:
[DEBUG] CID  | reprog? | fn key? | mouse key? | gesture support?
[DEBUG] 0x50 |         |         | YES        | 
[DEBUG] 0x51 |         |         | YES        | 
[DEBUG] 0x52 | YES     |         | YES        | YES
[DEBUG] 0x53 | YES     |         | YES        | YES
[DEBUG] 0x56 | YES     |         | YES        | YES
[DEBUG] 0xc3 | YES     |         | YES        | YES
[DEBUG] 0xc4 | YES     |         | YES        | YES
[DEBUG] 0xd7 | YES     |         |            | YES
[DEBUG] 0x1a0 | YES     |         | YES        | YES
[DEBUG] Thumb wheel detected (0x2150), capabilities:
[DEBUG] timestamp | touch | proximity | single tap
[DEBUG] YES       | YES   | NO        | NO        
[DEBUG] Thumb wheel resolution: native (20), diverted (120)
```

And here's the output with these changes:

```console
$ cd build/
$ cmake -DCMAKE_BUILD_TYPE=Release ..
$ make
$ sudo ./logid -v
[DEBUG] Unsupported device /dev/hidraw4 ignored
[DEBUG] Unsupported device /dev/hidraw1 ignored
[DEBUG] Unsupported device /dev/hidraw2 ignored
[DEBUG] Unsupported device /dev/hidraw3 ignored
[DEBUG] Unsupported device /dev/hidraw0 ignored
[INFO] Device found: MX Master 4 on /dev/hidraw5:255
[DEBUG] /dev/hidraw5:255 remappable buttons:
[DEBUG] CID   | reprog? | fn key? | mouse key? | gesture support?
[DEBUG] 0x050 |         |         | YES        | 
[DEBUG] 0x051 |         |         | YES        | 
[DEBUG] 0x052 | YES     |         | YES        | YES
[DEBUG] 0x053 | YES     |         | YES        | YES
[DEBUG] 0x056 | YES     |         | YES        | YES
[DEBUG] 0x0c3 | YES     |         | YES        | YES
[DEBUG] 0x0c4 | YES     |         | YES        | YES
[DEBUG] 0x0d7 | YES     |         |            | YES
[DEBUG] 0x1a0 | YES     |         | YES        | YES
[DEBUG] Thumb wheel detected (0x2150), capabilities:
[DEBUG] timestamp | touch | proximity | single tap
[DEBUG] YES       | YES   | NO        | NO        
[DEBUG] Thumb wheel resolution: native (20), diverted (120)
```