### PR TITLE
Fix thumbwheel bidirectional scrolling and add touch/tap gestures

### DIFF
--- a/src/logid/InputDevice.cpp
+++ b/src/logid/InputDevice.cpp
@@ -19,6 +19,7 @@
 #include <InputDevice.h>
 #include <system_error>
 #include <mutex>
+#include <util/log.h>
 
 extern "C"
 {
@@ -99,6 +100,7 @@ void InputDevice::registerAxis(uint axis) {
 }
 
 void InputDevice::moveAxis(uint axis, int movement) {
+    logPrintf(WARN, "InputDevice Debug: Sending EV_REL axis=%u value=%d", axis, movement);
     _sendEvent(EV_REL, axis, movement);
 }
 

--- a/src/logid/config/types.h
+++ b/src/logid/config/types.h
@@ -192,6 +192,22 @@ namespace logid::config {
     template<>
     struct config_io<double> : public primitive_io<double,
             libconfig::Setting::TypeFloat> {
+        static double get(const libconfig::Setting& setting) {
+            switch (setting.getType()) {
+                case libconfig::Setting::TypeInt:
+                    return (double) (int) setting;
+                case libconfig::Setting::TypeInt64:
+                    return (double) (long long) setting;
+                case libconfig::Setting::TypeFloat:
+                default:
+                    return (double) setting;
+            }
+        }
+
+        static double get(const libconfig::Setting& parent,
+                          const std::string& name) {
+            return get(parent.lookup(name));
+        }
     };
     template<>
     struct config_io<std::string> : public primitive_io<std::string,

--- a/src/logid/features/ThumbWheel.h
+++ b/src/logid/features/ThumbWheel.h
@@ -22,6 +22,8 @@
 #include <actions/gesture/Gesture.h>
 #include <backend/hidpp20/features/ThumbWheel.h>
 #include <backend/hidpp/Device.h>
+#include <chrono>
+#include <atomic>
 
 namespace logid::features {
     class ThumbWheel : public DeviceFeature {
@@ -85,6 +87,12 @@ namespace logid::features {
 
         bool _last_proxy = false;
         bool _last_touch = false;
+        
+        // Smart touch detection
+        std::chrono::system_clock::time_point _touch_time;
+        std::atomic<bool> _touch_pending{false};
+        std::atomic<bool> _touch_active{false};
+        static constexpr int TOUCH_DELAY_MS = 150;
 
         mutable std::shared_mutex _config_mutex;
         std::reference_wrapper<std::optional<config::ThumbWheel>> _config;


### PR DESCRIPTION
# Fix thumbwheel bidirectional scrolling and add touch/tap gestures (MX Master 3S)

## Summary

This PR fixes the thumbwheel left direction issue (#536) and adds comprehensive gesture support for the thumbwheel, enabling simultaneous use of **scrolling**, **tap**, and **touch** gestures on devices like the MX Master 3S.

## Changes Overview

### 1. **Fixed Bidirectional Scrolling** (Fixes #536)
   - Left scrolling now works correctly on MX Master 3S thumbwheel
   - Both directions respond immediately without threshold delays
   - Symmetric behavior in both directions

### 2. **Added Touch Gesture Support**
   - Smart touch detection with configurable delay (150ms default)
   - Prevents false touch triggers during scrolling
   - Touch action fires only if finger remains on wheel without scrolling

### 3. **Added Tap Gesture Support**
   - Single tap detection on thumbwheel
   - Independent from touch and scroll gestures

### 4. **Improved Config Parsing**
   - Fixed `double` type parsing to accept both integers and floats
   - Allows `axis_multiplier: 1` (was requiring `1.0`)

---

## Root Cause Analysis (Issue #536)

The left scrolling issue stemmed from three problems:

### Problem 1: Accumulator Reset in `ThumbWheel.cpp`
```cpp
// BEFORE (Line 203):
if (scroll_action) {
    scroll_action->press(false);  // ← Reset _axis to 0 before each move
    scroll_action->move(event.rotation);
}

// AFTER:
if (scroll_action) {
    scroll_action->move(event.rotation);  // Just move, don't reset
}
```
**Impact:** `press(false)` was resetting the accumulator to 0 before each move, preventing negative values from accumulating properly.

### Problem 2: Asymmetric Threshold Initialization in `ThumbWheel.cpp`
```cpp
// REMOVED (Lines 187-192):
// REMOVED (Lines 187-192):
if (event.rotationStatus == hidpp20::ThumbWheel::Start) {
    if (_right_gesture)
        _right_gesture->press(true);  // Sets _axis = +50
    if (_left_gesture)
        _left_gesture->press(true);   // Sets _axis = +50
}
```
**Impact:** `press(true)` set `_axis = +50` for both gestures, creating asymmetric behavior:
- **Right (+2):** `50 + 2 = 52 > 50` → Works immediately
- **Left (-2):** `50 - 2 = 48 < 50` → Required ~51 clicks to reach threshold

### Problem 3: Missing Negative Value Support in `AxisGesture.cpp`
```cpp
// BEFORE (Line 86):
if (new_axis > threshold) {

// AFTER:
if (std::abs(new_axis) > threshold) {
```
```cpp
// BEFORE (Lines 88-94):
if (_axis < threshold)
    move = new_axis - threshold;

// AFTER:
if (std::abs(_axis) < threshold) {
    if (new_axis > 0)
        move = new_axis - threshold;
    else
        move = new_axis + threshold;
}
```
**Impact:** Original code didn't handle negative input values and had flawed sign-flipping logic for `axis_multiplier`.

---

## Detailed Changes

### `src/logid/features/ThumbWheel.cpp`

#### Touch Gesture Enhancement
- Added smart touch detection with 150ms delay
- Prevents false touch triggers when user is scrolling
- Touch action only fires if finger remains still on wheel
- Properly cancels pending touch on tap or scroll events

```cpp
// New members in ThumbWheel.h
std::chrono::system_clock::time_point _touch_time;
std::atomic<bool> _touch_pending{false};
std::atomic<bool> _touch_active{false};
static constexpr int TOUCH_DELAY_MS = 150;
```

#### Scroll Gesture Fix
- Removed `press(true)` initialization that set `_axis = +50`
- Removed `press(false)` call before each move
- Now calls `move()` directly with rotation value

#### Tap Gesture Support
- Added tap detection from `ThumbwhheelEvent::SingleTap` flag
- Cancels pending touch on tap to prevent conflicts

### `src/logid/actions/gesture/AxisGesture.cpp`

#### Bidirectional Support
- Changed threshold check to `std::abs(new_axis) > threshold`
- Fixed threshold crossing logic for both positive and negative directions
- Simplified `axis_multiplier` application (removed complex negative handling)

#### Multiplier Calculation
- Removed baking of `axis_multiplier` into `_multiplier` during `setHiresMultiplier()`
- Now applies `axis_multiplier` directly in `move()` for correct behavior

#### Debug Support
- Added `release()` to reset `_axis` to 0
- Added debug logging (can be removed if desired)

### `src/logid/config/types.h`

#### Config Type Parsing
- Extended `config_io<double>` to accept `TypeInt` and `TypeInt64`
- Allows cleaner configs: `axis_multiplier: 1` instead of requiring `1.0`

### `src/logid/InputDevice.cpp`

#### Debug Support
- Added debug logging for axis movements (can be removed if desired)

---

## Testing

Tested extensively on **Logitech MX Master 3S** with the following configuration:

```libconfig
devices:(
    {
        name:        "MX Master 3S";
        dpi:         1000;
        smartshift: {on: true;       threshold: 10; torque: 50;   };
        hiresscroll:{hires: true;    invert: false; target: false;};                  
        buttons:    (    
                         // {cid: 0x50; action = {type: "Keypress";         keys: ["BTN_LEFT"                       ];};},  //LEWY  -> no reprog
                         // {cid: 0x51; action = {type: "Keypress";         keys: ["BTN_RIGHT"                      ];};},  //PRAWY -> no reprog
                            {cid: 0x52; action = {type: "Keypress";         keys: ["BTN_MIDDLE"                     ];};},  //ŚRODKOWY
                            {cid: 0x53; action = {type: "Keypress";         keys: ["KEY_LEFTALT"                    ];};},  //BOCZNY TYŁ
                            {cid: 0x56; action = {type: "Keypress";         keys: ["KEY_LEFTCTRL", "KEY_LEFTSHIFT"  ];};},  //BOCZNY PRZÓD
                            {cid: 0xc4; action = {type: "Keypress";         keys: ["KEY_DELETE"                     ];};},  //ZA KÓŁKIEM
                            {cid: 0xc3; action = {type: "Keypress";         keys: ["KEY_LEFTCTRL", "KEY_Z"          ];};}   //BOCZNY DÓŁ
                    );
 thumbwheel:
    {
        divert: true;invert: false;
        left:  {mode: "Axis";axis: "REL_HWHEEL_HI_RES" ;axis_multiplier: 0.25 ; threshold:10;};
        right: {mode: "Axis";axis: "REL_HWHEEL_HI_RES" ;axis_multiplier: 0.25 ; threshold:10;};
        tap:   {type: "Keypress"; keys: ["KEY_A"] ;};
        touch: {type: "Keypress"; keys: ["KEY_LEFTCTRL"] ;};
        //proxy: {type: "OnRelease"; keys: ["KEY_B"]; }; 
    };
  }        
);
```

**Device Detection Output:**
```
[INFO] Device found: MX Master 3S on /dev/hidraw6:255
[DEBUG] /dev/hidraw6:255 remappable buttons:
[DEBUG] CID  | reprog? | fn key? | mouse key? | gesture support?
[DEBUG] 0x50 |         |         | YES        | 
[DEBUG] 0x51 |         |         | YES        | 
[DEBUG] 0x52 | YES     |         | YES        | YES
[DEBUG] 0x53 | YES     |         | YES        | YES
[DEBUG] 0x56 | YES     |         | YES        | YES
[DEBUG] 0xc3 | YES     |         | YES        | YES
[DEBUG] 0xc4 | YES     |         | YES        | YES
[DEBUG] 0xd7 | YES     |         |            | YES
[DEBUG] Thumb wheel detected (0x2150), capabilities:
[DEBUG] timestamp | touch | proximity | single tap
[DEBUG] YES       | YES   | YES       | YES       
[DEBUG] Thumb wheel resolution: native (18), diverted (120)
```

### Test Results
- **Both scroll directions work immediately** - no threshold delay  
- **Tap gesture fires correctly** on single tap  
- **Touch gesture fires after 150ms** if no scrolling occurs  
- **Touch cancels on scroll/tap** - no false triggers  
- **All gestures work simultaneously** - scroll while holding touch modifier  
- **Positive and negative `axis_multiplier` work correctly**  
- **Config accepts both `1` and `1.0` for multipliers**  

### Regression Testing
- **Regular mouse buttons** - no impact  
- **Main scroll wheel** - no impact  
- **SmartShift** - no impact  
- **Other devices** - changes only affect thumbwheel gesture handling  

---

## Usage Examples

### Example 1: Horizontal Scrolling
```libconfig
thumbwheel: {
    divert: true;
    left:  { mode: "Axis"; axis: "REL_HWHEEL_HI_RES"; axis_multiplier: 0.25; };
    right: { mode: "Axis"; axis: "REL_HWHEEL_HI_RES"; axis_multiplier: 0.25; };
};
```

### Example 2: Scroll + Touch Modifier (e.g., Ctrl+Scroll for zoom)
```libconfig
thumbwheel: {
    divert: true;
    left:  { mode: "Axis"; axis: "REL_HWHEEL_HI_RES"; axis_multiplier: 0.25; };
    right: { mode: "Axis"; axis: "REL_HWHEEL_HI_RES"; axis_multiplier: 0.25; };
    touch: { type: "Keypress"; keys: ["KEY_LEFTCTRL"]; };  // Hold Ctrl while scrolling
};
```

### Example 3: Full Feature Set
```libconfig
thumbwheel: {
    divert: true;
    left:  { mode: "Axis"; axis: "REL_HWHEEL_HI_RES"; axis_multiplier: 0.25; };
    right: { mode: "Axis"; axis: "REL_HWHEEL_HI_RES"; axis_multiplier: 0.25; };
    tap:   { type: "Keypress"; keys: ["KEY_PLAYPAUSE"]; };  // Media control
    touch: { type: "Keypress"; keys: ["KEY_LEFTALT"]; };    // Modifier for apps
};
```

---

## Technical Details

### Touch Detection Algorithm
1. **Touch starts** → Start 150ms timer
2. **During 150ms:**
   - If **tap** detected → Cancel touch, fire tap action
   - If **scroll** detected → Cancel touch, perform scroll
   - If **touch ends** → Cancel pending touch
3. **After 150ms:**
   - If still touching without movement → Fire touch action
4. **Touch ends** → Always release touch action if active

### Why 150ms Delay?
- Prevents false touch triggers when user intends to scroll
- Short enough to feel responsive
- Long enough to distinguish between scroll and deliberate touch

---

## Files Changed

- `src/logid/features/ThumbWheel.cpp` - Touch/tap/scroll gesture handling
- `src/logid/features/ThumbWheel.h` - Touch detection state members
- `src/logid/actions/gesture/AxisGesture.cpp` - Bidirectional axis support
- `src/logid/config/types.h` - Double type parsing enhancement
- `src/logid/InputDevice.cpp` - Debug logging (optional)

---

## Acknowledgments

Thanks to the logiops community for this excellent project! This fix makes the MX Master 3S thumbwheel finally work as intended.

---

## Related Issues

Fixes #536