### PR TITLE
Add optional delay cooldown to OnInterval gestures

### DIFF
--- a/logid.example.cfg
+++ b/logid.example.cfg
@@ -80,11 +80,12 @@ devices: (
 // {
 //     direction: "Right";
 //     mode: "OnInterval";
-//     interval: 30;
-//     delay: 150;
+//     interval: 100;
+//     delay: 250;
 //     action =
 //     {
 //         type: "Keypress";
-//         keys: ["KEY_LEFTCTRL", "KEY_PAGEDOWN"];
+//         keys: ["KEY_LEFTCTRL", "KEY_TAB"];
 //     };
 // }
+

--- a/logid.example.cfg
+++ b/logid.example.cfg
@@ -75,3 +75,16 @@ devices: (
     );
 }
 );
+
+// Example OnInterval gesture with delay to avoid overshooting repeated actions.
+// {
+//     direction: "Right";
+//     mode: "OnInterval";
+//     interval: 30;
+//     delay: 150;
+//     action =
+//     {
+//         type: "Keypress";
+//         keys: ["KEY_LEFTCTRL", "KEY_PAGEDOWN"];
+//     };
+// }

--- a/src/logid/actions/gesture/IntervalGesture.cpp
+++ b/src/logid/actions/gesture/IntervalGesture.cpp
@@ -29,14 +29,17 @@ IntervalGesture::IntervalGesture(
         Gesture(device, parent, interface_name, {
                 {
                         {"GetConfig", {this, &IntervalGesture::getConfig, {"interval", "threshold"}}},
+                        {"GetDelay", {this, &IntervalGesture::getDelay, {"delay"}}},
                         {"SetInterval", {this, &IntervalGesture::setInterval, {"interval"}}},
+                        {"SetDelay", {this, &IntervalGesture::setDelay, {"delay"}}},
                         {"SetThreshold", {this, &IntervalGesture::setThreshold, {"interval"}}},
                         {"SetAction", {this, &IntervalGesture::setAction, {"type"}}}
                 },
                 {},
                 {}
         }),
-        _axis(0), _interval_pass_count(0), _config(config) {
+        _axis(0), _interval_pass_count(0), _config(config),
+        _next_action_time(std::nullopt) {
     if (config.action) {
         try {
             _action = Action::makeAction(device, config.action.value(), _node);
@@ -47,20 +50,23 @@ IntervalGesture::IntervalGesture(
 }
 
 void IntervalGesture::press(bool init_threshold) {
-    std::shared_lock lock(_config_mutex);
+    std::unique_lock lock(_config_mutex);
     if (init_threshold) {
         _axis = (int32_t) _config.threshold.value_or(defaults::gesture_threshold);
     } else {
         _axis = 0;
     }
     _interval_pass_count = 0;
+    _next_action_time.reset();
 }
 
 void IntervalGesture::release([[maybe_unused]] bool primary) {
+    std::unique_lock lock(_config_mutex);
+    _next_action_time.reset();
 }
 
 void IntervalGesture::move(int16_t axis) {
-    std::shared_lock lock(_config_mutex);
+    std::unique_lock lock(_config_mutex);
     if (!_config.interval.has_value())
         return;
 
@@ -72,9 +78,20 @@ void IntervalGesture::move(int16_t axis) {
 
     int32_t new_interval_count = (_axis - threshold) / _config.interval.value();
     if (new_interval_count > _interval_pass_count) {
-        if (_action) {
+        const auto delay = _config.delay.value_or(0);
+        const bool cooldown_enabled = delay > 0;
+        const auto now = cooldown_enabled ? Clock::now() : Clock::time_point{};
+        const bool cooldown_expired = !cooldown_enabled
+                                      || !_next_action_time.has_value()
+                                      || now >= _next_action_time.value();
+        if (_action && cooldown_expired) {
             _action->press();
             _action->release();
+            if (cooldown_enabled) {
+                _next_action_time = now + std::chrono::milliseconds(delay);
+            } else {
+                _next_action_time.reset();
+            }
         }
     }
     _interval_pass_count = new_interval_count;
@@ -94,12 +111,26 @@ std::tuple<int, int> IntervalGesture::getConfig() const {
     return {_config.interval.value_or(0), _config.threshold.value_or(0)};
 }
 
+int IntervalGesture::getDelay() const {
+    std::shared_lock lock(_config_mutex);
+    return _config.delay.value_or(0);
+}
+
 void IntervalGesture::setInterval(int interval) {
     std::unique_lock lock(_config_mutex);
     if (interval == 0)
         _config.interval.reset();
     else
         _config.interval = interval;
+}
+
+void IntervalGesture::setDelay(int delay) {
+    std::unique_lock lock(_config_mutex);
+    if (delay == 0)
+        _config.delay.reset();
+    else
+        _config.delay = delay;
+    _next_action_time.reset();
 }
 
 void IntervalGesture::setThreshold(int threshold) {

--- a/src/logid/actions/gesture/IntervalGesture.cpp
+++ b/src/logid/actions/gesture/IntervalGesture.cpp
@@ -70,6 +70,14 @@ void IntervalGesture::move(int16_t axis) {
     if (!_config.interval.has_value())
         return;
 
+    const auto delay = _config.delay.value_or(0);
+    const bool cooldown_enabled = delay > 0;
+    const auto now = cooldown_enabled ? Clock::now() : Clock::time_point{};
+    if (cooldown_enabled && _next_action_time.has_value()
+        && now < _next_action_time.value()) {
+        return;
+    }
+
     const auto threshold =
             _config.threshold.value_or(defaults::gesture_threshold);
     _axis += axis;
@@ -78,17 +86,14 @@ void IntervalGesture::move(int16_t axis) {
 
     int32_t new_interval_count = (_axis - threshold) / _config.interval.value();
     if (new_interval_count > _interval_pass_count) {
-        const auto delay = _config.delay.value_or(0);
-        const bool cooldown_enabled = delay > 0;
-        const auto now = cooldown_enabled ? Clock::now() : Clock::time_point{};
-        const bool cooldown_expired = !cooldown_enabled
-                                      || !_next_action_time.has_value()
-                                      || now >= _next_action_time.value();
-        if (_action && cooldown_expired) {
+        if (_action) {
             _action->press();
             _action->release();
             if (cooldown_enabled) {
                 _next_action_time = now + std::chrono::milliseconds(delay);
+                _axis = threshold;
+                _interval_pass_count = 0;
+                return;
             } else {
                 _next_action_time.reset();
             }

--- a/src/logid/actions/gesture/IntervalGesture.h
+++ b/src/logid/actions/gesture/IntervalGesture.h
@@ -19,10 +19,14 @@
 #define LOGID_ACTION_INTERVALGESTURE_H
 
 #include <actions/gesture/Gesture.h>
+#include <chrono>
+#include <optional>
 
 namespace logid::actions {
     class IntervalGesture : public Gesture {
     public:
+        using Clock = std::chrono::steady_clock;
+
         static const char* interface_name;
 
         IntervalGesture(Device* device, config::IntervalGesture& config,
@@ -40,7 +44,11 @@ namespace logid::actions {
 
         [[nodiscard]] std::tuple<int, int> getConfig() const;
 
+        [[nodiscard]] int getDelay() const;
+
         void setInterval(int interval);
+
+        void setDelay(int delay);
 
         void setThreshold(int threshold);
 
@@ -51,6 +59,7 @@ namespace logid::actions {
         int32_t _interval_pass_count;
         std::shared_ptr<Action> _action;
         config::IntervalGesture& _config;
+        std::optional<Clock::time_point> _next_action_time;
     private:
     };
 }

--- a/src/logid/config/schema.h
+++ b/src/logid/config/schema.h
@@ -159,13 +159,15 @@ namespace logid::config {
         std::optional<int> threshold;
         std::optional<BasicAction> action;
         std::optional<int> interval;
+        std::optional<int> delay;
     protected:
         explicit IntervalGesture(const std::string& name) : signed_group(
                 "mode", name,
-                {"threshold", "action", "interval"},
+                {"threshold", "action", "interval", "delay"},
                 &IntervalGesture::threshold,
                 &IntervalGesture::action,
-                &IntervalGesture::interval) {}
+                &IntervalGesture::interval,
+                &IntervalGesture::delay) {}
 
     public:
         IntervalGesture() : IntervalGesture("OnInterval") {}


### PR DESCRIPTION
## Summary

This PR adds support for an optional `delay` field on interval-based gestures.

`delay` is expressed in milliseconds and rate-limits repeated `OnInterval` activations. After an action fires, additional interval crossings are ignored until the cooldown expires.

This is intended to make `OnInterval` more precise for discrete repeated actions such as tab switching or repeated left/right navigation.

## Motivation

My main use case is on a Logitech MX Master 4.

I use `OnInterval` for repeated left/right actions, including browser tab navigation. Without a cooldown, a single hand movement can cross multiple interval boundaries very quickly, which makes it easy to overshoot and trigger more actions than intended.

A small delay makes the gesture much easier to control while keeping it responsive.

## Example use case

```cfg
{
    direction: "Right";
    mode: "OnInterval";
    interval: 100;
    delay: 250;
    action =
    {
        type: "Keypress";
        keys: ["KEY_LEFTCTRL", "KEY_TAB"];
    };
}

## Behaviour

- delay > 0 enables cooldown behavior
- omitted delay keeps the existing behavior unchanged
- after an OnInterval action fires, the next action cannot fire until delay ms have elapsed
- interval crossings during the cooldown are ignored 

## Implementation
This PR:

- adds optional delay to config::IntervalGesture
- applies the same support to OnFewPixels, since it shares the same interval-based schema/runtime path
- updates IntervalGesture to use a std::chrono::steady_clock-based cooldown
- adds GetDelay() / SetDelay(int delay) IPC methods
- adds a small example snippet to logid.example.cfg