### PR TITLE
Fix scroll remainder accumulation in AxisGesture

### DIFF
--- a/src/logid/actions/gesture/AxisGesture.cpp
+++ b/src/logid/actions/gesture/AxisGesture.cpp
@@ -94,6 +94,8 @@ void AxisGesture::move(int16_t axis) {
         // Handle hi-res multiplier
         move *= _multiplier;
 
+        move += _axis_remainder;
+
         double move_floor = floor(move);
         _axis_remainder = move - move_floor;
         if (_axis_remainder >= 1) {


### PR DESCRIPTION
### Summary
This PR fixes a bug in `AxisGesture` where the fractional remainder of scroll movements (`_axis_remainder`) is calculated and saved but never added back to the movement delta of subsequent scroll events. 
### Why this is needed
When a small `axis_multiplier` (such as `0.1` or `0.07`) is used with high-resolution scrolling, individual scroll events are scaled down to fractional values less than `1.0` (e.g., `0.8`). Because the remainder is never accumulated, `floor()` truncates all movements to `0`, making the scroll wheel completely unresponsive (dead) at slow scrolling speeds. 
By adding `move += _axis_remainder;` before calculating `move_floor`, fractional scroll inputs successfully pool together and trigger scroll ticks as expected, allowing users to configure slow, comfortable scroll speeds without losing precision.