### PR TITLE
Add MX Master 3S For Mac to tested devices

### DIFF
--- a/TESTED.md
+++ b/TESTED.md
@@ -3,22 +3,23 @@
 This is not by any means an exhaustive list. Many more devices are supported but these devices are the ones that are confirmed to be working. To add to this list, submit a pull request adding your device.
 
 
-| Device              | Compatible? |              Config Name               |
-| :-----------------: | :---------: | :------------------------------------: |
-| LIFT                |     Yes     | `LIFT VERTICAL ERGONOMIC MOUSE`        |
-| MX Master 4         |     Yes     | `MX Master 4`                          |
-| MX Master 3S        |     Yes     | `MX Master 3S`                         |
-| MX Master 3         |     Yes     | `Wireless Mouse MX Master 3`           |
-| MX Master 3 for Mac |     Yes     | `MX Master 3 for Mac`                  |
-| MX Master 2S        |     Yes     | `Wireless Mouse MX Master 2S`          |
-| MX Master           |     Yes     | `Wireless Mouse MX Master`             |
-| MX Anywhere 2S      |     Yes     | `Wireless Mobile Mouse MX Anywhere 2S` |
-| MX Anywhere 3       |     Yes     | `MX Anywhere 3`                        |
-| MX Vertical         |     Yes     | `MX Vertical Advanced Ergonomic Mouse` |
-| MX Ergo             |     Yes     | `MX Ergo Multi-Device Trackball `      |
-| MX Ergo M575        |     Yes     | `ERGO M575 Trackball`                  |
-| M720                |     Yes     | `M720 Triathlon Multi-Device Mouse`    |
-| M590                |     Yes     | `M585/M590 Multi-Device Mouse`         |
-| T400                |     Yes     | `Zone Touch Mouse T400`                |
-| MX Keys             |     Yes     | `MX Keys Wireless Keyboard`            |
-| M500s               |     Yes     | `Advanced Corded Mouse M500s`          |
+| Device               | Compatible? |              Config Name               |
+| :------------------: | :---------: | :------------------------------------: |
+| LIFT                 |     Yes     | `LIFT VERTICAL ERGONOMIC MOUSE`        |
+| MX Master 4          |     Yes     | `MX Master 4`                          |
+| MX Master 3S         |     Yes     | `MX Master 3S`                         |
+| MX Master 3S for Mac |     Yes     | `MX Master 3S For Mac`                 |
+| MX Master 3          |     Yes     | `Wireless Mouse MX Master 3`           |
+| MX Master 3 for Mac  |     Yes     | `MX Master 3 for Mac`                  |
+| MX Master 2S         |     Yes     | `Wireless Mouse MX Master 2S`          |
+| MX Master            |     Yes     | `Wireless Mouse MX Master`             |
+| MX Anywhere 2S       |     Yes     | `Wireless Mobile Mouse MX Anywhere 2S` |
+| MX Anywhere 3        |     Yes     | `MX Anywhere 3`                        |
+| MX Vertical          |     Yes     | `MX Vertical Advanced Ergonomic Mouse` |
+| MX Ergo              |     Yes     | `MX Ergo Multi-Device Trackball `      |
+| MX Ergo M575         |     Yes     | `ERGO M575 Trackball`                  |
+| M720                 |     Yes     | `M720 Triathlon Multi-Device Mouse`    |
+| M590                 |     Yes     | `M585/M590 Multi-Device Mouse`         |
+| T400                 |     Yes     | `Zone Touch Mouse T400`                |
+| MX Keys              |     Yes     | `MX Keys Wireless Keyboard`            |
+| M500s                |     Yes     | `Advanced Corded Mouse M500s`          |


### PR DESCRIPTION
Adding `MX Master 3S For Mac` to list of tested devices.
Note the difference in capitalization of `For`.
<img width="877" height="32" alt="Terminal" src="https://github.com/user-attachments/assets/b28e051f-c405-4908-ac57-d51075a18a51" />
<img width="2394" height="1780" alt="Mouse" src="https://github.com/user-attachments/assets/8e0372d4-a9d8-4d30-8331-720d278dfbec" />


All lines appear changed to maintain the alignment of the table.